### PR TITLE
fix(gltf): avoid stack overflow from Math.min/max spreads on large joint arrays

### DIFF
--- a/src/converters/gltf/gltf-converter.ts
+++ b/src/converters/gltf/gltf-converter.ts
@@ -410,8 +410,8 @@ export async function convertGlbToUsdz(
                   mappingLength: gjointToUjointMap.length,
                   mappingSample: gjointToUjointMap.slice(0, 10),
                   skeletonJointCount,
-                  originalIndicesMin: Math.min(...indicesArray),
-                  originalIndicesMax: Math.max(...indicesArray),
+                  originalIndicesMin: indicesArray.reduce((a: number, b: number) => a < b ? a : b, Infinity),
+                  originalIndicesMax: indicesArray.reduce((a: number, b: number) => a > b ? a : b, -Infinity),
                   originalIndicesUnique: new Set(indicesArray).size,
                   originalIndicesSample: indicesArray.slice(0, 20)
                 });
@@ -472,10 +472,10 @@ export async function convertGlbToUsdz(
                 logger.info('Validated joint indices for USD skeleton', {
                   originalIndicesSample: indicesArray.slice(0, 20),
                   validatedIndicesSample: remappedIndices.slice(0, 20),
-                  minOriginal: Math.min(...indicesArray),
-                  maxOriginal: Math.max(...indicesArray),
-                  minValidated: Math.min(...remappedIndices),
-                  maxValidated: Math.max(...remappedIndices),
+                  minOriginal: indicesArray.reduce((a: number, b: number) => a < b ? a : b, Infinity),
+                  maxOriginal: indicesArray.reduce((a: number, b: number) => a > b ? a : b, -Infinity),
+                  minValidated: remappedIndices.reduce((a: number, b: number) => a < b ? a : b, Infinity),
+                  maxValidated: remappedIndices.reduce((a: number, b: number) => a > b ? a : b, -Infinity),
                   uniqueOriginal: new Set(indicesArray).size,
                   uniqueValidated: new Set(remappedIndices).size,
                   changedIndicesCount: changedIndices.length,

--- a/src/converters/gltf/helpers/skeleton-processor.ts
+++ b/src/converters/gltf/helpers/skeleton-processor.ts
@@ -903,8 +903,8 @@ export function bindSkeletonToMesh(
 
   // Log joint indices statistics
   if (jointIndices.length > 0) {
-    const minIndex = Math.min(...jointIndices);
-    const maxIndex = Math.max(...jointIndices);
+    const minIndex = jointIndices.reduce((a, b) => a < b ? a : b, Infinity);
+    const maxIndex = jointIndices.reduce((a, b) => a > b ? a : b, -Infinity);
     const uniqueIndices = new Set(jointIndices).size;
 
     // Get skeleton joint count (from parameter or skeleton prim)
@@ -947,8 +947,8 @@ export function bindSkeletonToMesh(
 
   // Log joint weights statistics
   if (jointWeights.length > 0) {
-    const minWeight = Math.min(...jointWeights);
-    const maxWeight = Math.max(...jointWeights);
+    const minWeight = jointWeights.reduce((a, b) => a < b ? a : b, Infinity);
+    const maxWeight = jointWeights.reduce((a, b) => a > b ? a : b, -Infinity);
     const sumWeights = jointWeights.reduce((a, b) => a + b, 0);
     logger.info('Joint weights statistics', {
       minWeight,


### PR DESCRIPTION
First off, thank you for the incredible work. I have a tiny web conversor called [gltf2usdz.online](https://github.com/arthurrmp/gltf2usdz.online), currently powered by Google's [`usd_from_gltf`](https://github.com/google/usd_from_gltf) running inside a Docker container. I'm planning to migrate it to WebUsdFramework so the whole pipeline becomes pure JS/TS. This PR is the first of a couple of correctness fixes I hit while testing that migration.

## The bug

Several `info`-level log calls in `gltf-converter.ts` and `skeleton-processor.ts` spread the entire `JOINTS_0` / joint-index / joint-weight arrays into `Math.min` and `Math.max`:

```ts
Math.min(...indicesArray)
Math.max(...jointIndices)
```

V8 raises `RangeError: Maximum call stack size exceeded` once a spread gets past ~100,000 arguments. A skinned primitive with 25k vertices already has 100k `JOINTS_0` values, so any moderately-rigged character crashes the converter.

The crashing log lines are at `info` level (not `debug`), so passing `debug: false` does **not** prevent the crash. There's no way to opt out without patching.

## Fix

Replace the variable-length spreads with `.reduce()`. 10 call sites:

- `src/converters/gltf/gltf-converter.ts`: 6 (two log blocks)
- `src/converters/gltf/helpers/skeleton-processor.ts`: 4 (joint indices and weights stats)

Fixed-arity calls like `Math.max(0, Math.min(a, b))` and `Math.min(...paths.map(p => p.length))` (where `paths` is short) are left alone.

## Reproduction

[repro.zip](https://github.com/user-attachments/files/26642026/repro.zip) contains a skinned GLB (~4 MB, 165k `JOINTS_0` values), which comfortably exceeds V8's spread limit
```ts
// repro.ts
import { defineConfig } from './src/index';

defineConfig().convert('./repro.glb')
  .then(blob => console.log(`OK: ${(blob.size / 1024 / 1024).toFixed(2)} MB`))
  .catch(e => { console.error('CRASH:', e.message); process.exit(1); });
```

```bash
pnpm tsx repro.ts
```

**Before this PR:**
```
CRASH: Maximum call stack size exceeded
  at convertGlbToUsdz (.../gltf-converter.ts:413:34)
```

**After:**
```
OK: 74.37 MB
```

Output `.usdz` also validates clean with `usdchecker`.



