### PR TITLE
fix: validate triangle assumption and add sampler null warning

### DIFF
--- a/src/converters/shared/usd-geometry-builder.ts
+++ b/src/converters/shared/usd-geometry-builder.ts
@@ -68,20 +68,40 @@ export function extractRawGeometryData(primitive: Primitive): RawGeometryData {
   if (indices) {
     const indexArray = indices.getArray();
     if (indexArray && indexArray.length > 0) {
-      const faceCount = indexArray.length / 3;
+      // Validate that geometry is fully triangulated (indexArray.length must be divisible by 3).
+      // gltf-transform's triangulate() transform should guarantee this; warn if it didn't.
+      if (indexArray.length % 3 !== 0) {
+        console.warn(
+          `[extractPrimitiveData] Index count (${indexArray.length}) is not divisible by 3. ` +
+          `Geometry may not be fully triangulated. Face topology will be incorrect.`
+        );
+      }
+      const faceCount = Math.floor(indexArray.length / 3);
       faceVertexCounts = Array(faceCount).fill(3).join(', ');
       faceVertexIndices = Array.from(indexArray).join(', ');
     } else {
       // Fallback
       const vertexCount = positionArray.length / 3;
-      const faceCount = vertexCount / 3;
+      if (vertexCount % 3 !== 0) {
+        console.warn(
+          `[extractPrimitiveData] Vertex count (${vertexCount}) is not divisible by 3. ` +
+          `Non-indexed geometry may not be fully triangulated.`
+        );
+      }
+      const faceCount = Math.floor(vertexCount / 3);
       faceVertexCounts = Array(faceCount).fill(3).join(', ');
       faceVertexIndices = Array.from({ length: vertexCount }, (_, i) => i).join(', ');
     }
   } else {
     // Non-indexed geometry
     const vertexCount = positionArray.length / 3;
-    const faceCount = vertexCount / 3;
+    if (vertexCount % 3 !== 0) {
+      console.warn(
+        `[extractPrimitiveData] Vertex count (${vertexCount}) is not divisible by 3. ` +
+        `Non-indexed geometry may not be fully triangulated.`
+      );
+    }
+    const faceCount = Math.floor(vertexCount / 3);
     faceVertexCounts = Array(faceCount).fill(3).join(', ');
     faceVertexIndices = Array.from({ length: vertexCount }, (_, i) => i).join(', ');
   }

--- a/src/converters/shared/usd-material-builder.ts
+++ b/src/converters/shared/usd-material-builder.ts
@@ -999,6 +999,12 @@ function getTextureWrapModes(textureInfo: TextureInfo | null): { wrapS: 'repeat'
   let wrapS: 'repeat' | 'clamp' | 'mirror' = 'repeat';
   let wrapT: 'repeat' | 'clamp' | 'mirror' = 'repeat';
 
+  if (!textureInfo) {
+    // textureInfo is null — no sampler data available; falling back to GLTF defaults (repeat/repeat)
+    console.warn('[getTextureWrapModes] TextureInfo is null; defaulting to wrapS=repeat, wrapT=repeat');
+    return { wrapS, wrapT };
+  }
+
   if (textureInfo) {
     // Get wrap modes from TextureInfo (which includes sampler properties)
     const wrapSMode = textureInfo.getWrapS();


### PR DESCRIPTION
## Summary

### BUG #6 — Face count assumes all triangles (usd-geometry-builder.ts)
- `indexArray.length / 3` was producing a fractional faceCount if geometry was not triangulated
- Now asserts `indexArray.length % 3 === 0` and warns when violated; uses `Math.floor()` as a safety net
- Applied to all three code paths (indexed, indexed-fallback, non-indexed)

### BUG #8 — Silent null sampler fallback (usd-material-builder.ts)
- `getTextureWrapModes(null)` silently returned repeat/repeat with no log
- Now emits `console.warn` when `textureInfo` is null, making the fallback visible

Closes #34
Closes #35