### PR TITLE
fix: handle CUBICSPLINE interpolation stride in node/skeleton animation processors

### DIFF
--- a/src/converters/gltf/helpers/processors/node-animation-processor.ts
+++ b/src/converters/gltf/helpers/processors/node-animation-processor.ts
@@ -181,10 +181,15 @@ export class NodeAnimationProcessor implements IAnimationProcessor {
       const times = Array.from(inputArray as Float32Array);
       const values = Array.from(outputArray as Float32Array);
 
+      // Check interpolation mode — CUBICSPLINE stores 3× the data per keyframe
+      // Layout: [inTangent, value, outTangent] per component per keyframe
+      const interpolation = sampler.getInterpolation();
+
       this.logger.info(`Processing animation channel`, {
         animationName,
         targetNode: targetNode.getName(),
         targetPath,
+        interpolation,
         timeSampleCount: times.length,
         valueCount: values.length,
         expectedValueCount: targetPath === 'rotation' ? times.length * 4 : times.length * 3
@@ -199,10 +204,12 @@ export class NodeAnimationProcessor implements IAnimationProcessor {
       // Store animation values for this node at each time point
       const timeSamples = new Map<number, string>();
       const componentCount = targetPath === 'rotation' ? 4 : 3;
+      // CUBICSPLINE: stride is 3× componentCount (inTangent + value + outTangent)
+      const stride = interpolation === 'CUBICSPLINE' ? componentCount * 3 : componentCount;
 
       for (let i = 0; i < times.length; i++) {
         const time = times[i];
-        const startIdx = i * componentCount;
+        const startIdx = i * stride + (interpolation === 'CUBICSPLINE' ? componentCount : 0);
         const value = values.slice(startIdx, startIdx + componentCount);
 
         // Make sure we have enough values

--- a/src/converters/gltf/helpers/processors/skeleton-animation-processor.ts
+++ b/src/converters/gltf/helpers/processors/skeleton-animation-processor.ts
@@ -327,6 +327,10 @@ export class SkeletonAnimationProcessor implements IAnimationProcessor {
         const values = Array.from(outputArray as Float32Array);
         const targetPath = channel.getTargetPath();
 
+        // Check interpolation mode — CUBICSPLINE stores 3× the data per keyframe
+        // Layout: [inTangent, value, outTangent] per component per keyframe
+        const interpolation = sampler.getInterpolation();
+
         let jointAnim = jointAnimations.get(jointPath);
         if (!jointAnim) {
           jointAnim = { jointPath };
@@ -336,10 +340,12 @@ export class SkeletonAnimationProcessor implements IAnimationProcessor {
         // Store the animation values for this joint at each time point
         const timeSamples = new Map<number, string>();
         const componentCount = targetPath === 'rotation' ? 4 : 3;
+        // CUBICSPLINE: stride is 3× componentCount (inTangent + value + outTangent)
+        const stride = interpolation === 'CUBICSPLINE' ? componentCount * 3 : componentCount;
 
         for (let i = 0; i < times.length; i++) {
           const time = times[i];
-          const startIdx = i * componentCount;
+          const startIdx = i * stride + (interpolation === 'CUBICSPLINE' ? componentCount : 0);
           const value = values.slice(startIdx, startIdx + componentCount);
 
           let valueString: string;


### PR DESCRIPTION
## Summary
- CUBICSPLINE stores `[inTangent, value, outTangent]` per keyframe (3x data); both processors were using LINEAR stride
- Now reads `sampler.getInterpolation()` and offsets into the value component for CUBICSPLINE
- Fixes both `node-animation-processor.ts` and `skeleton-animation-processor.ts`

Closes #37