### PR TITLE
fix: propagate double-sided flag from GLTF material to USD mesh

### DIFF
--- a/src/converters/gltf/helpers/usd-hierarchy-builder.ts
+++ b/src/converters/gltf/helpers/usd-hierarchy-builder.ts
@@ -649,6 +649,11 @@ async function processMaterial(
 
   bindMaterial(targetNode, materialInfo);
 
+  // Propagate double-sided flag from GLTF material to USD mesh
+  if (material.getDoubleSided()) {
+    targetNode.setProperty('uniform bool doubleSided', 'true', 'bool');
+  }
+
   return context.materialCounter;
 }
 


### PR DESCRIPTION
## Summary
- Sets `uniform bool doubleSided = true` on USD Mesh prims when the GLTF material has `doubleSided: true`

## Root Cause
`processMaterial` in `usd-hierarchy-builder.ts` never read `material.getDoubleSided()`, so back faces were always culled in USD viewers for materials that should render both sides.

Closes #47