### PR TITLE
fix: prevent sibling name collisions after USD name sanitization

### DIFF
--- a/src/converters/gltf/helpers/usd-hierarchy-builder.ts
+++ b/src/converters/gltf/helpers/usd-hierarchy-builder.ts
@@ -109,7 +109,20 @@ export async function buildNodeHierarchy(
   parentUsdNode: UsdNode,
   context: HierarchyBuilderContext
 ): Promise<number> {
-  const nodeName = generateNodeName(gltfNode);
+  let nodeName = generateNodeName(gltfNode);
+
+  // Prevent sibling name collisions after sanitization.
+  // E.g. "Cube!" and "Cube?" both sanitize to "Cube" — append a numeric
+  // suffix to make each child name unique under its parent.
+  const siblingNames = new Set(Array.from(parentUsdNode.getChildren()).map(c => c.getName()));
+  if (siblingNames.has(nodeName)) {
+    let suffix = 1;
+    while (siblingNames.has(`${nodeName}_${suffix}`)) {
+      suffix++;
+    }
+    nodeName = `${nodeName}_${suffix}`;
+  }
+
   const nodeType = determineNodeType(gltfNode);
 
   const currentNode = new UsdNode(


### PR DESCRIPTION
## Summary
- After generating a sanitized node name, checks if the parent already has a child with that name
- If collision detected, appends incrementing numeric suffix (`_1`, `_2`, ...)
- Prevents invalid USD with duplicate prim names under the same parent

Closes #53