### PR TITLE
Add warnings for unsupported camera nodes and multi-scene GLBs

### DIFF
--- a/src/converters/gltf/gltf-converter.ts
+++ b/src/converters/gltf/gltf-converter.ts
@@ -134,7 +134,13 @@ export async function convertGlbToUsdz(
 
     // Create USD root structure
     const root = document.getRoot();
-    const scene = root.listScenes()[CONVERSION_CONSTANTS.FIRST_SCENE_INDEX];
+    const allScenes = root.listScenes();
+    if (allScenes.length > 1) {
+      console.warn(
+        `[WebUsdFramework] GLB contains ${allScenes.length} scenes — only the first scene ("${allScenes[0].getName() || 'unnamed'}") will be converted. ${allScenes.length - 1} scene(s) will be skipped.`
+      );
+    }
+    const scene = allScenes[CONVERSION_CONSTANTS.FIRST_SCENE_INDEX];
     const sceneName = scene.getName();
     const rootStructure = createRootStructure(sceneName);
 

--- a/src/converters/gltf/helpers/usd-hierarchy-builder.ts
+++ b/src/converters/gltf/helpers/usd-hierarchy-builder.ts
@@ -136,6 +136,14 @@ export async function buildNodeHierarchy(
   // Add to node map for animation processing
   context.nodeMap.set(gltfNode, currentNode);
 
+  // Warn if this node has a camera (not yet supported in USDZ export)
+  const camera = gltfNode.getCamera();
+  if (camera) {
+    console.warn(
+      `[WebUsdFramework] Node "${nodeName}" has a camera ("${camera.getName() || 'unnamed'}") attached — cameras are not supported in USDZ and will be skipped.`
+    );
+  }
+
   const mesh = gltfNode.getMesh();
   if (mesh) {
     context.materialCounter = await processMesh(


### PR DESCRIPTION
## Summary
- Adds `console.warn` when a GLTF node has a camera attached (cameras are not supported in USDZ export)
- Adds `console.warn` when a GLB contains multiple scenes (only the first scene is converted)

## Changes
- `src/converters/gltf/helpers/usd-hierarchy-builder.ts` — check `gltfNode.getCamera()` and warn
- `src/converters/gltf/gltf-converter.ts` — check `listScenes().length > 1` and warn

Closes #65