### PR TITLE
Extract rest pose rotations and scales for joint animation defaults

### DIFF
--- a/src/converters/gltf/helpers/processors/skeleton-animation-processor.ts
+++ b/src/converters/gltf/helpers/processors/skeleton-animation-processor.ts
@@ -528,8 +528,10 @@ export class SkeletonAnimationProcessor implements IAnimationProcessor {
         const rotArray: string[] = [];
         const scaleArray: string[] = [];
 
-        // Use rest pose translations as defaults for joints without translation animation
+        // Use rest pose TRS as defaults for joints without animation channels
         const restPoseTranslations = targetSkeleton.restPoseTranslations || [];
+        const restPoseRotations = targetSkeleton.restPoseRotations || [];
+        const restPoseScales = targetSkeleton.restPoseScales || [];
 
         if (time === sortedTimes[0] && restPoseTranslations.length > 0) {
           this.logger.debug('Using rest pose translations as defaults', {
@@ -555,19 +557,23 @@ export class SkeletonAnimationProcessor implements IAnimationProcessor {
             transArray.push(defaultTranslation);
           }
 
-          // Get rotation, using default if this joint doesn't animate
+          // Get rotation, using rest pose if this joint doesn't animate
           // Use SLERP interpolation for rotations (isQuaternion = true)
+          const defaultRotation =
+            i < restPoseRotations.length ? restPoseRotations[i] : '(1, 0, 0, 0)';
           if (jointAnim?.rotations) {
-            rotArray.push(getValueAtTime(jointAnim.rotations, time, '(1, 0, 0, 0)', true));
+            rotArray.push(getValueAtTime(jointAnim.rotations, time, defaultRotation, true));
           } else {
-            rotArray.push('(1, 0, 0, 0)');
+            rotArray.push(defaultRotation);
           }
 
-          // Get scale, using default if this joint doesn't animate
+          // Get scale, using rest pose if this joint doesn't animate
+          const defaultScale =
+            i < restPoseScales.length ? restPoseScales[i] : '(1, 1, 1)';
           if (jointAnim?.scales) {
-            scaleArray.push(getValueAtTime(jointAnim.scales, time, '(1, 1, 1)'));
+            scaleArray.push(getValueAtTime(jointAnim.scales, time, defaultScale));
           } else {
-            scaleArray.push('(1, 1, 1)');
+            scaleArray.push(defaultScale);
           }
         }
 

--- a/src/converters/gltf/helpers/skeleton-processor.ts
+++ b/src/converters/gltf/helpers/skeleton-processor.ts
@@ -19,6 +19,8 @@ export interface SkeletonData {
   jointRelativePaths: string[]; // Relative paths (for USD joints array)
   restTransforms?: string[]; // Store rest transforms for animation comparison
   restPoseTranslations?: string[]; // Store rest pose translations (extracted from rest transforms) for default animation values
+  restPoseRotations?: string[]; // Store rest pose rotations in USD (w,x,y,z) format for default animation values
+  restPoseScales?: string[]; // Store rest pose scales for default animation values
   rootJointOmitted?: boolean; // Whether the root joint was omitted from the skeleton
   gjointToUjointMap?: number[]; // Map GLTF joint index (in skin.listJoints()) to USD skeleton joint index
 }
@@ -441,24 +443,26 @@ function createSkeleton(
     'raw'
   );
 
-  // Extract rest pose translations from rest transforms for use as default animation values
-  // When a joint doesn't have translation animation data, we use its rest pose translation instead of (0, 0, 0)
-  // Extract translations directly from joint transforms before converting to string format
+  // Extract rest pose TRS from joint transforms for use as default animation values
+  // When a joint doesn't have animation data for a channel, we use its rest pose value
+  // instead of identity, preventing joints from snapping to wrong positions
   const restPoseTranslations: string[] = [];
+  const restPoseRotations: string[] = [];
+  const restPoseScales: string[] = [];
   for (let i = 0; i < joints.length; i++) {
     const joint = joints[i];
-    const jointTransform = joint.getMatrix();
-    if (jointTransform) {
-      // GLTF matrices are column-major: [m00, m10, m20, m30, m01, m11, m21, m31, m02, m12, m22, m32, m03, m13, m23, m33]
-      // Translation is at indices 12, 13, 14 (m03, m13, m23)
-      const tx = jointTransform[12];
-      const ty = jointTransform[13];
-      const tz = jointTransform[14];
-      restPoseTranslations.push(`(${tx}, ${ty}, ${tz})`);
-    } else {
-      // If joint has no transform, use (0, 0, 0)
-      restPoseTranslations.push('(0, 0, 0)');
-    }
+    const translation = joint.getTranslation();
+    const rotation = joint.getRotation(); // GLTF: (x, y, z, w)
+    const scale = joint.getScale();
+
+    // Translation
+    restPoseTranslations.push(`(${translation[0]}, ${translation[1]}, ${translation[2]})`);
+
+    // Rotation: convert GLTF (x, y, z, w) → USD (w, x, y, z)
+    restPoseRotations.push(`(${rotation[3]}, ${rotation[0]}, ${rotation[1]}, ${rotation[2]})`);
+
+    // Scale
+    restPoseScales.push(`(${scale[0]}, ${scale[1]}, ${scale[2]})`);
   }
 
   // Create mapping from GLTF joint indices to USD skeleton joint indices
@@ -520,6 +524,8 @@ function createSkeleton(
     jointRelativePaths, // Relative paths (for USD joints array)
     restTransforms, // Store rest transforms for animation comparison
     restPoseTranslations, // Store rest pose translations for default animation values
+    restPoseRotations, // Store rest pose rotations for default animation values
+    restPoseScales, // Store rest pose scales for default animation values
     rootJointOmitted: omitRootJoint, // Track if root joint was omitted
     gjointToUjointMap // Map GLTF joint index to USD skeleton joint index
   };


### PR DESCRIPTION
## Summary
- Extracts rest pose rotations and scales from joints (previously only translations were extracted)
- Uses rest pose TRS as defaults when a joint lacks animation channels, instead of identity values
- Adds `restPoseRotations` and `restPoseScales` to `SkeletonData` interface
- Properly swizzles GLTF (x,y,z,w) → USD (w,x,y,z) quaternion format for rest pose rotations

## Changes
- `skeleton-processor.ts` — Extract all three TRS components using `getTranslation/getRotation/getScale`
- `skeleton-animation-processor.ts` — Use rest pose rotations/scales as defaults for unanimated joints

Closes #67