### PR TITLE
Fix unlit materials to use emissive channel instead of roughness hack

### DIFF
--- a/src/converters/shared/usd-material-builder.ts
+++ b/src/converters/shared/usd-material-builder.ts
@@ -919,13 +919,38 @@ export async function buildUsdMaterial(
   }
 
   if (allProperties.unlit === true) {
-    // For unlit materials, disable all lighting calculations
-    // Set roughness to 1.0 and metallic to 0.0 to simulate unlit appearance
+    // For unlit materials, route base color through emissive channel (lighting-independent)
+    // UsdPreviewSurface has no native "unlit" mode, so we:
+    // 1. Move base color (texture or factor) from diffuseColor → emissiveColor
+    // 2. Set diffuseColor to black (no lit contribution)
+    // 3. Set roughness=1, metallic=0 (prevent specular highlights)
+    
+    // Check if base color texture was connected to diffuseColor
+    const diffuseConnection = surfaceShader.getProperty('color3f inputs:diffuseColor.connect');
+    if (diffuseConnection && typeof diffuseConnection === 'string') {
+      // Redirect: connect the same texture to emissiveColor instead
+      surfaceShader.setProperty(
+        'color3f inputs:emissiveColor.connect',
+        diffuseConnection,
+        'connection'
+      );
+    } else {
+      // No texture — use the diffuseColor value as emissiveColor
+      const diffuseValue = surfaceShader.getProperty('color3f inputs:diffuseColor');
+      if (diffuseValue && typeof diffuseValue === 'string') {
+        surfaceShader.setProperty('color3f inputs:emissiveColor', diffuseValue);
+      }
+    }
+
+    // Zero out diffuseColor so lighting doesn't contribute
+    surfaceShader.setProperty('color3f inputs:diffuseColor', '(0, 0, 0)');
+    // Remove the diffuse connection if it existed (we moved it to emissive)
+    if (diffuseConnection) {
+      surfaceShader.removeProperty('color3f inputs:diffuseColor.connect');
+    }
     surfaceShader.setProperty('float inputs:roughness', '1.0', 'float');
     surfaceShader.setProperty('float inputs:metallic', '0.0', 'float');
-    // Note: USD PreviewSurface doesn't have a direct "unlit" mode,
-    // but high roughness + no metallic approximates unlit appearance
-    console.log(`[buildUsdMaterial] Material marked as unlit: ${materialName}`);
+    console.log(`[buildUsdMaterial] Material marked as unlit (using emissive channel): ${materialName}`);
   }
 
   // Add shared UV reader and Transform2d nodes to material

--- a/src/core/usd-node.ts
+++ b/src/core/usd-node.ts
@@ -85,6 +85,18 @@ export class UsdNode {
   }
 
   /**
+   * Remove a property by key. Returns true if the property was found and removed.
+   */
+  removeProperty(key: string): boolean {
+    const existingIndex = this._properties.findIndex(p => p.key === key);
+    if (existingIndex !== -1) {
+      this._properties.splice(existingIndex, 1);
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * Add a reference to this node (for USDZ generation)
    */
   addReference(target: string, primPath?: string): this {


### PR DESCRIPTION
## Summary
- Routes base color (texture or factor) through emissive channel for `KHR_materials_unlit`
- Sets diffuseColor to black so lighting doesn't contribute
- Adds `removeProperty()` method to `UsdNode` for proper connection cleanup

## Changes
- `usd-material-builder.ts` — Redirect diffuseColor connection/value to emissiveColor for unlit materials
- `usd-node.ts` — Add `removeProperty()` method

Closes #75