### PR TITLE
Fix emissive strength overwrite, non-indexed geometry, and control bone heuristic

### DIFF
--- a/src/converters/gltf/helpers/usd-hierarchy-builder.ts
+++ b/src/converters/gltf/helpers/usd-hierarchy-builder.ts
@@ -411,7 +411,7 @@ function attachGeometryReference(
     extentMax = [maxX, maxY, maxZ];
   }
 
-  // Face vertex counts (how many vertices per face)
+  // Face vertex counts and indices
   if (indices) {
     const faceCounts = new Array(indices.getCount() / 3).fill(3);
     node.setProperty('int[] faceVertexCounts', `[${faceCounts.join(', ')}]`, 'raw');
@@ -422,6 +422,18 @@ function attachGeometryReference(
       const indicesList = formatUsdNumberArray(Array.from(indexArray));
       node.setProperty('int[] faceVertexIndices', indicesList, 'raw');
     }
+  } else if (positionArray) {
+    // Non-indexed geometry (valid per GLTF spec): generate sequential indices
+    const vertexCount = positionArray.length / 3;
+    const faceCount = Math.floor(vertexCount / 3);
+    const faceCounts = new Array(faceCount).fill(3);
+    node.setProperty('int[] faceVertexCounts', `[${faceCounts.join(', ')}]`, 'raw');
+
+    const sequentialIndices: number[] = [];
+    for (let i = 0; i < faceCount * 3; i++) {
+      sequentialIndices.push(i);
+    }
+    node.setProperty('int[] faceVertexIndices', formatUsdNumberArray(sequentialIndices), 'raw');
   }
 
   // Normals (if available) - add with interpolation property
@@ -533,17 +545,7 @@ function attachGeometryReference(
   // Add standard mesh properties
   node.setProperty('token subdivisionScheme', 'none', 'token');
   node.setProperty('token visibility', 'inherited', 'token');
-
-  // Set purpose to "guide" for control bones/helpers (hide from rendering)
-  // These are typically named with "Bone" in the name and are helper geometry
-  const nodePath = node.getPath();
-  const isControlBone = nodePath.includes('Bone') || nodePath.includes('_Bone_') || nodePath.includes('Armature');
-
-  if (isControlBone) {
-    node.setProperty('token purpose', 'guide', 'token');
-  } else {
-    node.setProperty('token purpose', 'default', 'token');
-  }
+  node.setProperty('token purpose', 'default', 'token');
 }
 
 /**

--- a/src/converters/shared/usd-material-builder.ts
+++ b/src/converters/shared/usd-material-builder.ts
@@ -884,11 +884,21 @@ export async function buildUsdMaterial(
   if (allProperties.emissiveStrength !== undefined) {
     const strength = allProperties.emissiveStrength as number;
     if (emissiveTextureShaderNode) {
-      // Emissive is texture-connected: apply strength as scale on the texture shader.
-      // This multiplies the texture output by the strength value.
+      // Emissive is texture-connected: multiply existing scale (emissiveFactor) by strength.
+      // The existing scale was set from emissiveFactor — we must preserve that color tint.
+      const currentScale = emissiveTextureShaderNode.getProperty('float4 inputs:scale');
+      let sr = strength, sg = strength, sb = strength;
+      if (currentScale && typeof currentScale === 'string') {
+        const match = currentScale.match(/\(([^,]+),\s*([^,]+),\s*([^,]+),\s*([^)]+)\)/);
+        if (match) {
+          sr = parseFloat(match[1]) * strength;
+          sg = parseFloat(match[2]) * strength;
+          sb = parseFloat(match[3]) * strength;
+        }
+      }
       emissiveTextureShaderNode.setProperty(
         'float4 inputs:scale',
-        `(${strength}, ${strength}, ${strength}, 1)`,
+        `(${sr}, ${sg}, ${sb}, 1)`,
         'float4'
       );
     } else {


### PR DESCRIPTION
## Summary
Three HIGH severity bug fixes:

1. **Emissive strength × factor** — `inputs:scale` now multiplies existing emissiveFactor instead of overwriting it. A red emissive material with 2× strength now correctly renders as red×2 instead of white×2.

2. **Non-indexed geometry** — GLTF primitives without index buffers (valid per spec) now generate sequential indices and face vertex counts, instead of producing invalid faceless USD meshes that render as nothing.

3. **Control bone heuristic removed** — The heuristic that hid any geometry with "Bone" or "Armature" in the path caused false positives (Trombone, Backbone, etc.). GLTF has no concept of guide geometry, so this has been removed.

## Changes
- `usd-material-builder.ts` — Read existing scale before multiplying by emissive strength
- `usd-hierarchy-builder.ts` — Add non-indexed geometry handling + remove isControlBone heuristic

Closes #77, #78, #79