### PR TITLE
Fix root joint detection, Math.max stack overflow, and multi-animation warning

### DIFF
--- a/src/converters/gltf/helpers/processors/morph-target-animation-processor.ts
+++ b/src/converters/gltf/helpers/processors/morph-target-animation-processor.ts
@@ -230,7 +230,9 @@ export class MorphTargetAnimationProcessor implements IAnimationProcessor {
       }
 
       if (times.length > 0) {
-        maxTime = Math.max(maxTime, ...times);
+        for (const t of times) {
+          if (t > maxTime) maxTime = t;
+        }
       }
 
       // Store weights for each time sample

--- a/src/converters/gltf/helpers/processors/node-animation-processor.ts
+++ b/src/converters/gltf/helpers/processors/node-animation-processor.ts
@@ -105,7 +105,9 @@ export class NodeAnimationProcessor implements IAnimationProcessor {
       }
 
       if (times.length > 0) {
-        maxTime = Math.max(maxTime, ...times);
+        for (const t of times) {
+          if (t > maxTime) maxTime = t;
+        }
       }
     }
 
@@ -339,10 +341,22 @@ export class NodeAnimationProcessor implements IAnimationProcessor {
     }
 
     for (const [usdNode, nodeAnim] of nodeAnimations) {
+      // Warn if this node already has decomposed animation ops (from a previous animation clip)
+      // USDZ doesn't support multiple animation clips on the same prim without composition arcs
+      const existingOps = usdNode.getProperty('xformOpOrder');
+      if (existingOps && Array.isArray(existingOps)) {
+        const opsArray = existingOps as string[];
+        if (opsArray.includes('xformOp:translate') || opsArray.includes('xformOp:orient') || opsArray.includes('xformOp:scale')) {
+          console.warn(
+            `[WebUsdFramework] Node "${usdNode.getPath()}" already has animation from a previous clip. ` +
+            `Animation "${animationName}" will overwrite it. USDZ only supports one animation per node.`
+          );
+        }
+      }
+
       // Remove existing xformOp:transform if present (USD doesn't allow mixing transform types)
       const existingTransform = usdNode.getProperty('xformOp:transform');
       if (existingTransform) {
-        const existingOps = usdNode.getProperty('xformOpOrder');
         if (existingOps && Array.isArray(existingOps)) {
           const filteredOps = (existingOps as string[]).filter(op => op !== 'xformOp:transform');
           usdNode.setProperty('xformOpOrder', filteredOps, 'token[]');

--- a/src/converters/gltf/helpers/processors/skeleton-animation-processor.ts
+++ b/src/converters/gltf/helpers/processors/skeleton-animation-processor.ts
@@ -231,7 +231,9 @@ export class SkeletonAnimationProcessor implements IAnimationProcessor {
         }
 
         if (times.length > 0) {
-          maxTime = Math.max(maxTime, ...times);
+          for (const t of times) {
+            if (t > maxTime) maxTime = t;
+          }
         }
       }
 

--- a/src/converters/gltf/helpers/skeleton-processor.ts
+++ b/src/converters/gltf/helpers/skeleton-processor.ts
@@ -116,22 +116,55 @@ export function processSkeletons(
   });
 
   for (const skin of skins) {
-    // Check if root joint should be omitted
-    // Only omit if it has no animation AND is not used by any meshes for skinning
+    // Find the actual root joint — don't assume joints[0] is the root
+    // Per GLTF spec, skin.joints is unordered. Use skin.getSkeleton() first,
+    // then fall back to finding the joint with no parent among the other joints.
     const joints = skin.listJoints();
     let shouldOmitRootJoint = false;
 
     if (joints.length > 0) {
-      const rootJoint = joints[0];
-      const hasAnimation = hasJointAnimation(rootJoint, document);
-      const isUsedByMeshes = isJointUsedByMeshes(0, skin, document); // Root joint is always index 0
+      const jointSet = new Set(joints);
+      let rootJoint: Node | null = skin.getSkeleton() || null;
+
+      // If getSkeleton() didn't return a joint in our set, find the parentless joint
+      if (!rootJoint || !jointSet.has(rootJoint)) {
+        rootJoint = null;
+        for (const joint of joints) {
+          const parent = joint.getParentNode();
+          // Root joint is one whose parent is either null or not in the joint set
+          if (!parent || !jointSet.has(parent)) {
+            rootJoint = joint;
+            break;
+          }
+        }
+      }
+
+      // If we found a root joint that isn't joints[0], reorder so root is first
+      // This preserves compatibility with downstream code that expects root at index 0
+      if (rootJoint && rootJoint !== joints[0]) {
+        const rootIndex = joints.indexOf(rootJoint);
+        if (rootIndex > 0) {
+          logger.info('Reordering joints: actual root joint is not at index 0', {
+            rootJointName: rootJoint.getName(),
+            originalIndex: rootIndex,
+            assumedRootName: joints[0].getName()
+          });
+          // Move root to front
+          joints.splice(rootIndex, 1);
+          joints.unshift(rootJoint);
+        }
+      }
+
+      const actualRoot = rootJoint || joints[0];
+      const hasAnimation = hasJointAnimation(actualRoot, document);
+      const isUsedByMeshes = isJointUsedByMeshes(joints.indexOf(actualRoot), skin, document);
 
       // Only omit root joint if it has no animation AND is not used by any meshes
       shouldOmitRootJoint = !hasAnimation && !isUsedByMeshes;
 
       if (shouldOmitRootJoint) {
         logger.info('Root joint omitted from skeleton (no animation and not used by meshes)', {
-          rootJointName: rootJoint.getName(),
+          rootJointName: actualRoot.getName(),
           totalJoints: joints.length,
           skeletonJoints: joints.length - 1,
           hasAnimation: false,
@@ -140,7 +173,7 @@ export function processSkeletons(
       } else {
         const reason = hasAnimation ? 'has animation' : 'is used by meshes for skinning';
         logger.info(`Root joint included in skeleton (${reason})`, {
-          rootJointName: rootJoint.getName(),
+          rootJointName: actualRoot.getName(),
           totalJoints: joints.length,
           hasAnimation,
           isUsedByMeshes


### PR DESCRIPTION
## Summary
Three HIGH severity fixes:

1. **Root joint detection** — No longer assumes `joints[0]` is the skeleton root. Uses `skin.getSkeleton()` first, then falls back to finding the joint with no parent among the joint set. Reorders joints array to put the actual root first.

2. **Math.max stack overflow** — `Math.max(maxTime, ...times)` spread can exceed JS call stack on long animations (>100K keyframes). Replaced with simple loop in all 3 animation processors.

3. **Multi-animation overwrite warning** — When multiple GLTF animation clips target the same node, warns that the previous clip's data will be overwritten (USDZ only supports one animation per node).

## Changes
- `skeleton-processor.ts` — Proper root joint detection via getSkeleton()/parentless joint search
- `node-animation-processor.ts` — Loop-based maxTime + multi-animation warning
- `morph-target-animation-processor.ts` — Loop-based maxTime
- `skeleton-animation-processor.ts` — Loop-based maxTime

Closes #81, #82, #83