### PR TITLE
fix: revert SkelAnimation scales from float3 to half3

### DIFF
--- a/src/converters/gltf/helpers/processors/skeleton-animation-processor.ts
+++ b/src/converters/gltf/helpers/processors/skeleton-animation-processor.ts
@@ -762,7 +762,7 @@ export class SkeletonAnimationProcessor implements IAnimationProcessor {
       // Set default values (the pose before animation starts)
       skelAnimationNode.setProperty('float3[] translations', defaultTranslations, 'raw');
       skelAnimationNode.setProperty('quatf[] rotations', defaultRotations, 'raw');
-      skelAnimationNode.setProperty('float3[] scales', defaultScales, 'raw');
+      skelAnimationNode.setProperty('half3[] scales', defaultScales, 'raw');
 
       // Set the time-sampled animation data
       if (transTimeCodes.size > 0) {
@@ -778,7 +778,7 @@ export class SkeletonAnimationProcessor implements IAnimationProcessor {
       }
 
       if (scaleTimeCodes.size > 0) {
-        skelAnimationNode.setTimeSampledProperty('float3[] scales', scaleTimeCodes, 'float3[]');
+        skelAnimationNode.setTimeSampledProperty('half3[] scales', scaleTimeCodes, 'half3[]');
       }
 
       // Add SkelAnimation as a child of Skeleton


### PR DESCRIPTION
## Summary
- Reverts SkelAnimation `scales` type from `float3[]` back to `half3[]` in `skeleton-animation-processor.ts`
- The USD SkelAnimation schema requires `half3[]` for scales; `float3[]` causes Apple Quick Look to silently ignore all skeleton animations
- Node-level `xformOp:scale` (in `node-animation-processor.ts`) correctly uses `float3` and is unaffected

Fixes #89