### PR TITLE
fix(converter): dedupe texture files when one image is used in multiple material slots

### DIFF
--- a/src/converters/gltf/extensions/processors/texture-utils.ts
+++ b/src/converters/gltf/extensions/processors/texture-utils.ts
@@ -31,6 +31,31 @@ export async function generateTextureId(texture: Texture, type: string): Promise
 }
 
 /**
+ * Strips the role suffix from a texture ID to produce a content-addressed
+ * basename suitable for file storage.
+ *
+ * `generateTextureId()` returns `<hash>_<role>` (e.g. `3ef307c5_diffuse`) so
+ * that shader node names stay unique within a material when one image is
+ * referenced in multiple slots. That composite ID must NOT be reused as the
+ * on-disk filename: the same bytes would then be written once per role,
+ * bloating the USDZ archive. This helper returns just the content-addressed
+ * portion.
+ *
+ * Uses `lastIndexOf('_')` rather than `indexOf('_')` so identifiers that
+ * intentionally carry a prefix (e.g. `vc_<hash>_baked` for vertex-color
+ * baked textures) keep their prefix and only lose the trailing role.
+ *
+ *   "3ef307c5_diffuse"   -> "3ef307c5"
+ *   "3ef307c5_emissive"  -> "3ef307c5"
+ *   "vc_a1b2c3d4_baked"  -> "vc_a1b2c3d4"
+ *   "noSuffix"           -> "noSuffix"
+ */
+export function getTextureFileBasename(textureId: string): string {
+  const sep = textureId.lastIndexOf('_');
+  return sep > 0 ? textureId.substring(0, sep) : textureId;
+}
+
+/**
  * Extract texture transform from TextureInfo using KHR_texture_transform extension
  * Returns transform data (offset, scale, rotation) if present, undefined otherwise
  */

--- a/src/converters/shared/debug-writer.ts
+++ b/src/converters/shared/debug-writer.ts
@@ -6,6 +6,7 @@ import { Logger, LoggerFactory } from '../../utils';
 import { DIRECTORY_NAMES } from '../../constants/config';
 import { USD_FILE_NAMES, USD_DEFAULT_NAMES } from '../../constants/usd';
 import { getTextureExtensionFromData } from './usd-packaging';
+import { getTextureFileBasename } from '../gltf/extensions/processors/texture-utils';
 
 /**
  * Debug Output Content
@@ -88,11 +89,18 @@ async function writeTextureFiles(
   const texturesDir = path.join(debugDir, DIRECTORY_NAMES.TEXTURES);
   ensureDirectoryExists(texturesDir);
 
+  // Dedupe by content-addressed basename so a single image referenced in
+  // multiple shader roles (e.g. baseColor + emissive) is written once, not
+  // once per role. The composite textureId keeps role context at the shader
+  // graph level; the on-disk name must collapse back to the hash.
+  const writtenPaths = new Set<string>();
   for (const [textureId, textureData] of textureFiles) {
-    // Determine the correct file extension based on texture data
     const textureExtension = getTextureExtensionFromData(textureData);
-    const fileName = `${USD_DEFAULT_NAMES.TEXTURE_PREFIX}${textureId}.${textureExtension}`;
+    const basename = getTextureFileBasename(textureId);
+    const fileName = `${USD_DEFAULT_NAMES.TEXTURE_PREFIX}${basename}.${textureExtension}`;
     const texturePath = path.join(texturesDir, fileName);
+    if (writtenPaths.has(texturePath)) continue;
+    writtenPaths.add(texturePath);
     fs.writeFileSync(texturePath, Buffer.from(textureData));
     logger.info(`Written ${texturePath}`, { fileSize: textureData.byteLength });
   }

--- a/src/converters/shared/usd-material-builder.ts
+++ b/src/converters/shared/usd-material-builder.ts
@@ -19,6 +19,7 @@ import { ExtensionFactory } from '../gltf/extensions/extension-factory';
 import {
   generateTextureId,
   extractTextureTransform,
+  getTextureFileBasename,
   getCleanTextureImage,
   getTextureExtension
 } from '../gltf/extensions/processors/texture-utils';
@@ -339,7 +340,10 @@ export async function buildUsdMaterial(
     // Create texture shader for baked vertex color texture
     const textureShader = new UsdNode(`${materialPath}/${textureNodeName}`, 'Shader');
     textureShader.setProperty('uniform token info:id', 'UsdUVTexture');
-    textureShader.setProperty('asset inputs:file', `@textures/Texture_${textureId}.png@`, 'asset');
+    // Asset paths are content-addressed (hash only) so one image referenced
+    // in multiple roles resolves to a single file; the role suffix lives on
+    // the shader node name, not on disk.
+    textureShader.setProperty('asset inputs:file', `@textures/Texture_${getTextureFileBasename(textureId)}.png@`, 'asset');
     textureShader.setProperty('token inputs:sourceColorSpace', 'sRGB', 'token');
     textureShader.setProperty('token inputs:wrapS', 'repeat', 'token');
     textureShader.setProperty('token inputs:wrapT', 'repeat', 'token');
@@ -1248,7 +1252,8 @@ function createOptimizedTextureShader(
 
   // Detect the correct file extension based on texture data
   const textureExtension = getTextureExtension(texture);
-  textureShader.setProperty('asset inputs:file', `@textures/Texture_${textureId}.${textureExtension}@`, 'asset');
+  // Content-addressed asset path (see note in the companion .png site above).
+  textureShader.setProperty('asset inputs:file', `@textures/Texture_${getTextureFileBasename(textureId)}.${textureExtension}@`, 'asset');
 
   // Set color space based on texture type
   // Non-color data (normal maps, metallic-roughness, occlusion) must use raw/linear

--- a/src/converters/shared/usd-packaging.ts
+++ b/src/converters/shared/usd-packaging.ts
@@ -7,6 +7,7 @@ import {
 } from '../../constants/config';
 import { USD_FILE_NAMES, USD_DEFAULT_NAMES } from '../../constants/usd';
 import { UsdzZipWriter } from './usdz-zip-writer';
+import { getTextureFileBasename } from '../gltf/extensions/processors/texture-utils';
 
 /**
  * Package Configuration
@@ -57,12 +58,18 @@ export async function createUsdzPackage(
     zipWriter.addFile(geometryPath, new Uint8Array(geometryData));
   }
 
-  // Add texture files
+  // Add texture files — dedupe by content-addressed basename. One image
+  // referenced in multiple shader roles (e.g. baseColor + emissive) arrives
+  // here under multiple composite IDs ("<hash>_diffuse", "<hash>_emissive")
+  // but shares the same bytes; write only one archive entry per basename.
+  const writtenTexturePaths = new Set<string>();
   for (const [textureId, textureData] of content.textureFiles) {
-    // Determine the correct file extension based on texture data
     const textureExtension = getTextureExtensionFromData(textureData);
-    const textureName = `${USD_DEFAULT_NAMES.TEXTURE_PREFIX}${textureId}.${textureExtension}`;
+    const basename = getTextureFileBasename(textureId);
+    const textureName = `${USD_DEFAULT_NAMES.TEXTURE_PREFIX}${basename}.${textureExtension}`;
     const texturePath = `${DIRECTORY_NAMES.TEXTURES}/${textureName}`;
+    if (writtenTexturePaths.has(texturePath)) continue;
+    writtenTexturePaths.add(texturePath);
     zipWriter.addFile(texturePath, new Uint8Array(textureData));
   }
 


### PR DESCRIPTION
## Summary

When a GLTF material references the same image in multiple shader slots (e.g. baseColor + emissive, as in `the_last_stronghold_animated`), the converter was writing the image to disk / into the USDZ archive **once per role** — the same bytes under two different filenames (`Texture_<hash>_diffuse.jpg` and `Texture_<hash>_emissive.jpg`). The shader graph resolved correctly but the archive carried duplicated bytes.

Closes #95.

## Root cause

`generateTextureId(texture, type)` returns `<hash>_<role>` so shader node names inside a material stay unique when one image fills two slots. That composite ID was then used unchanged as the on-disk filename, conflating two concerns:

- **Shader-node identity** (needs role suffix — two nodes `Texture_<hash>_diffuse` and `Texture_<hash>_emissive` inside the same material).
- **File-on-disk identity** (should be content-addressed — same bytes → one file).

## Fix

Introduce `getTextureFileBasename()` in `texture-utils.ts` which strips the trailing role segment using `lastIndexOf('_')`. Using `lastIndexOf` rather than `indexOf` preserves intentional prefixes — vertex-color baked texture IDs of the form `vc_<hash>_baked` correctly collapse to `vc_<hash>`, not `vc`.

Apply it at every site where the ID becomes a filesystem path:

| Site | Change |
|---|---|
| `usd-material-builder.ts:342, 1251` | `@textures/Texture_${getTextureFileBasename(textureId)}.ext@` |
| `usd-packaging.ts:61-66` | Same strip for zip entry path, plus `Set<string>` to skip duplicate `addFile` calls |
| `debug-writer.ts:91-97` | Same strip for disk filename, plus dedup set |

Shader node names (`Texture_<hash>_diffuse`, `Texture_<hash>_emissive`) are intentionally **untouched** — they still need the role suffix to avoid USD-path collisions inside a material.

## Test plan

- [x] `the_last_stronghold_animated_gltf/scene.gltf`: 10 texture files (was 11), USDZ 87.9 MB → 86.1 MB, oracle [PASS] with `missingTextureAssets: 0`. Verified both `sky_sketchfab` shader nodes (`Texture_3ef307c5_diffuse` and `Texture_3ef307c5_emissive`) correctly resolve `asset inputs:file = @textures/Texture_3ef307c5.jpg@`.
- [x] `12_animated_butterflies.glb`: no regression. Oracle [PASS], 0 missing assets.
- [x] `npx tsc --noEmit`: clean
- [x] `npm run build`: clean (CJS, ESM, UMD, .d.ts all built)

🤖 Generated with [Claude Code](https://claude.com/claude-code)