### PR TITLE
feat: add CLI with Effect TS Layer pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Node.js library for converting GLB/GLTF 3D models to USDZ format.",
   "private": false,
   "packageManager": "pnpm@10.18.3",
+  "bin": {
+    "webusd": "build/cli.js"
+  },
   "main": "build/index.js",
   "module": "build/index.esm.js",
   "types": "build/index.d.ts",
@@ -104,11 +107,14 @@
     "url": "git+https://github.com/chrismichaelps/WebUsdFramework.git"
   },
   "dependencies": {
+    "@effect/platform": "^0.96.0",
+    "@effect/platform-node": "^0.106.0",
     "@gltf-transform/core": "^4.2.1",
     "@gltf-transform/extensions": "^4.2.1",
     "@gltf-transform/functions": "^4.2.1",
     "canvas": "^3.2.0",
     "crc-32": "^1.2.2",
+    "effect": "^3.21.1",
     "fbx2gltf": "0.9.7-p1",
     "pngjs": "^7.0.0",
     "sharp": "^0.34.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ const commonjs = require('@rollup/plugin-commonjs');
 const { dts } = require('rollup-plugin-dts');
 
 // External dependencies that should not be bundled
+// External dependencies that should not be bundled
 const external = [
   // Node.js built-ins
   'fs',
@@ -24,6 +25,17 @@ const external = [
   '@gltf-transform/extensions',
   '@gltf-transform/functions',
   'zod',
+];
+
+const cliExternal = [
+  ...external,
+  'effect',
+  'effect/Context',
+  'effect/Layer',
+  'effect/Effect',
+  'effect/Data',
+  '@effect/platform',
+  '@effect/platform-node',
 ];
 
 const config = [
@@ -125,6 +137,30 @@ const config = [
       'https',
       'zlib',
     ],
+    plugins: [
+      resolve({
+        preferBuiltins: true,
+        browser: false,
+      }),
+      commonjs(),
+      typescript({
+        tsconfig: './tsconfig.json',
+        declaration: false,
+        declarationMap: false,
+        sourceMap: true,
+      }),
+    ],
+  },
+  // CLI bundle
+  {
+    input: 'src/cli/main.ts',
+    output: {
+      file: 'build/cli.js',
+      format: 'cjs',
+      sourcemap: true,
+      banner: '#!/usr/bin/env node',
+    },
+    external: cliExternal,
     plugins: [
       resolve({
         preferBuiltins: true,

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,52 @@
+/**
+ * CLI Entry Point
+ *
+ * Composes all service layers and runs the conversion program.
+ */
+
+import { Effect, Layer } from "effect"
+import { CliConfigLive, CliConfigError } from "./services/CliConfig"
+import { CliLoggerLive } from "./services/CliLogger"
+import { Converter, ConverterLive, ConversionError } from "./services/Converter"
+
+const AppConfigLive = Layer.merge(CliConfigLive, CliLoggerLive)
+
+const MainLive = ConverterLive.pipe(
+  Layer.provide(AppConfigLive),
+  Layer.provide(CliConfigLive),
+)
+
+const program = Effect.gen(function* () {
+  const converter = yield* Converter
+  yield* converter.run
+})
+
+const runnable = program.pipe(
+  Effect.provide(MainLive),
+  Effect.catchTag("CliConfigError", (e: CliConfigError) =>
+    Effect.sync(() => {
+      console.log(e.message)
+      process.exit(e.message.includes("Usage:") || e.message.startsWith("webusd v") ? 0 : 1)
+    }),
+  ),
+  Effect.catchTag("ConversionError", (e: ConversionError) =>
+    Effect.sync(() => {
+      console.error(`Error: ${e.message}`)
+      if (e.cause) {
+        console.error(`Cause: ${e.cause}`)
+      }
+      process.exit(1)
+    }),
+  ),
+  Effect.catchAll((e) =>
+    Effect.sync(() => {
+      console.error("Unexpected error:", e)
+      process.exit(1)
+    }),
+  ),
+)
+
+Effect.runPromise(runnable).catch((e) => {
+  console.error("Fatal:", e)
+  process.exit(1)
+})

--- a/src/cli/services/CliConfig.ts
+++ b/src/cli/services/CliConfig.ts
@@ -1,0 +1,162 @@
+/**
+ * CliConfig Service
+ *
+ * Parses CLI arguments into a typed configuration.
+ * No dependencies (Layer<CliConfig, never, never>).
+ */
+
+import { Effect, Context, Layer, Data } from "effect"
+
+export interface CliConfigShape {
+  readonly inputPath: string
+  readonly outputPath: string
+  readonly format: string
+  readonly debug: boolean
+  readonly decimateTarget: number
+  readonly upAxis: "Y" | "Z"
+  readonly metersPerUnit: number
+}
+
+export class CliConfig extends Context.Tag("CliConfig")<
+  CliConfig,
+  CliConfigShape
+>() {}
+
+export class CliConfigError extends Data.TaggedError("CliConfigError")<{
+  readonly message: string
+}> {}
+
+const SUPPORTED_EXTENSIONS = [".glb", ".gltf", ".obj", ".fbx", ".stl", ".ply"]
+
+const HELP_TEXT = `
+webusd - Convert 3D models to USDZ format
+
+Usage:
+  webusd <input> [options]
+
+Arguments:
+  input                    Path to the input file (.glb, .gltf, .obj, .fbx, .stl, .ply)
+
+Options:
+  -o, --output <path>      Output file path (default: <input>.usdz)
+  -d, --debug              Enable debug mode with intermediate files
+  --decimate <n>           Target face count for mesh decimation (PLY only, 0 = off)
+  --up-axis <Y|Z>          Up axis (default: Y)
+  --meters-per-unit <n>    Scene scale (default: 1)
+  -h, --help               Show this help message
+  -v, --version            Show version
+
+Supported Formats:
+  GLB, GLTF, OBJ, FBX, STL, PLY
+
+Examples:
+  webusd model.glb
+  webusd model.glb -o output.usdz -d
+  webusd scan.ply --decimate 500000
+  webusd ./stl-folder/
+`.trim()
+
+function parseArgs(argv: ReadonlyArray<string>): Effect.Effect<CliConfigShape, CliConfigError> {
+  return Effect.gen(function* () {
+    const args = argv.slice(2)
+
+    if (args.length === 0 || args.includes("-h") || args.includes("--help")) {
+      return yield* Effect.fail(new CliConfigError({ message: HELP_TEXT }))
+    }
+
+    if (args.includes("-v") || args.includes("--version")) {
+      return yield* Effect.fail(new CliConfigError({ message: "webusd v1.0.0" }))
+    }
+
+    let inputPath = ""
+    let outputPath = ""
+    let debug = false
+    let decimateTarget = 0
+    let upAxis: "Y" | "Z" = "Y"
+    let metersPerUnit = 1
+
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i]!
+      switch (arg) {
+        case "-o":
+        case "--output":
+          outputPath = args[++i] ?? ""
+          if (!outputPath) {
+            return yield* Effect.fail(new CliConfigError({ message: "Missing value for --output" }))
+          }
+          break
+        case "-d":
+        case "--debug":
+          debug = true
+          break
+        case "--decimate": {
+          const val = args[++i]
+          const n = Number(val)
+          if (!val || isNaN(n) || n < 0) {
+            return yield* Effect.fail(new CliConfigError({ message: "Invalid value for --decimate (must be >= 0)" }))
+          }
+          decimateTarget = Math.floor(n)
+          break
+        }
+        case "--up-axis": {
+          const val = args[++i]
+          if (val !== "Y" && val !== "Z") {
+            return yield* Effect.fail(new CliConfigError({ message: "Invalid value for --up-axis (must be Y or Z)" }))
+          }
+          upAxis = val
+          break
+        }
+        case "--meters-per-unit": {
+          const val = args[++i]
+          const n = Number(val)
+          if (!val || isNaN(n) || n <= 0) {
+            return yield* Effect.fail(new CliConfigError({ message: "Invalid value for --meters-per-unit (must be > 0)" }))
+          }
+          metersPerUnit = n
+          break
+        }
+        default:
+          if (arg.startsWith("-")) {
+            return yield* Effect.fail(new CliConfigError({ message: `Unknown option: ${arg}` }))
+          }
+          inputPath = arg
+      }
+    }
+
+    if (!inputPath) {
+      return yield* Effect.fail(new CliConfigError({ message: "No input file specified. Run webusd --help for usage." }))
+    }
+
+    const ext = inputPath.toLowerCase().slice(inputPath.lastIndexOf("."))
+    const isDirectory = !ext || !SUPPORTED_EXTENSIONS.includes(ext)
+
+    // For directories (STL batch mode) or files, validate extension
+    if (!isDirectory && !SUPPORTED_EXTENSIONS.includes(ext)) {
+      return yield* Effect.fail(new CliConfigError({
+        message: `Unsupported format: ${ext}\nSupported: ${SUPPORTED_EXTENSIONS.join(", ")}`
+      }))
+    }
+
+    const format = isDirectory ? ".stl" : ext
+
+    if (!outputPath) {
+      const base = inputPath.replace(/\.[^.]+$/, "")
+      outputPath = `${base}.usdz`
+    }
+
+    return {
+      inputPath,
+      outputPath,
+      format,
+      debug,
+      decimateTarget,
+      upAxis,
+      metersPerUnit,
+    }
+  })
+}
+
+export const CliConfigLive = Layer.effect(
+  CliConfig,
+  parseArgs(process.argv)
+)

--- a/src/cli/services/CliLogger.ts
+++ b/src/cli/services/CliLogger.ts
@@ -1,0 +1,59 @@
+/**
+ * CliLogger Service
+ *
+ * Structured console logging for the CLI.
+ * Depends on CliConfig (Layer<CliLogger, never, CliConfig>).
+ */
+
+import { Effect, Context, Layer } from "effect"
+import { CliConfig } from "./CliConfig"
+
+export interface CliLoggerShape {
+  readonly info: (message: string) => Effect.Effect<void>
+  readonly success: (message: string) => Effect.Effect<void>
+  readonly warn: (message: string) => Effect.Effect<void>
+  readonly error: (message: string) => Effect.Effect<void>
+  readonly debug: (message: string) => Effect.Effect<void>
+}
+
+export class CliLogger extends Context.Tag("CliLogger")<
+  CliLogger,
+  CliLoggerShape
+>() {}
+
+export const CliLoggerLive: Layer.Layer<CliLogger, never, CliConfig> = Layer.effect(
+  CliLogger,
+  Effect.gen(function* () {
+    const config = yield* CliConfig
+
+    const timestamp = () => {
+      const d = new Date()
+      return `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}:${d.getSeconds().toString().padStart(2, "0")}`
+    }
+
+    return {
+      info: (message: string) =>
+        Effect.sync(() => {
+          console.log(`[${timestamp()}] ${message}`)
+        }),
+      success: (message: string) =>
+        Effect.sync(() => {
+          console.log(`[${timestamp()}] ${message}`)
+        }),
+      warn: (message: string) =>
+        Effect.sync(() => {
+          console.warn(`[${timestamp()}] WARN ${message}`)
+        }),
+      error: (message: string) =>
+        Effect.sync(() => {
+          console.error(`[${timestamp()}] ERROR ${message}`)
+        }),
+      debug: (message: string) =>
+        Effect.sync(() => {
+          if (config.debug) {
+            console.log(`[${timestamp()}] DEBUG ${message}`)
+          }
+        }),
+    }
+  })
+)

--- a/src/cli/services/Converter.ts
+++ b/src/cli/services/Converter.ts
@@ -1,0 +1,188 @@
+/**
+ * Converter Service
+ *
+ * Orchestrates 3D model conversion to USDZ.
+ * Depends on CliConfig and CliLogger (Layer<Converter, never, CliConfig | CliLogger>).
+ */
+
+import { Effect, Context, Layer, Data } from "effect"
+import { CliConfig } from "./CliConfig"
+import { CliLogger } from "./CliLogger"
+import { defineConfig, convertPlyToUsdz } from "../../index"
+
+export class ConversionError extends Data.TaggedError("ConversionError")<{
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export interface ConverterShape {
+  readonly run: Effect.Effect<string, ConversionError>
+}
+
+export class Converter extends Context.Tag("Converter")<
+  Converter,
+  ConverterShape
+>() {}
+
+export const ConverterLive: Layer.Layer<Converter, never, CliConfig | CliLogger> = Layer.effect(
+  Converter,
+  Effect.gen(function* () {
+    const config = yield* CliConfig
+    const logger = yield* CliLogger
+
+    return {
+      run: Effect.gen(function* () {
+        yield* logger.info(`Input:  ${config.inputPath}`)
+        yield* logger.info(`Output: ${config.outputPath}`)
+        yield* logger.info(`Format: ${config.format}`)
+        yield* logger.debug(`Debug mode enabled`)
+        if (config.decimateTarget > 0) {
+          yield* logger.info(`Decimation target: ${config.decimateTarget} faces`)
+        }
+
+        const startTime = Date.now()
+
+        // Read input file
+        const fs = yield* Effect.try({
+          try: () => require("fs") as typeof import("fs"),
+          catch: (e) => new ConversionError({ message: "Failed to load fs module", cause: e }),
+        })
+
+        const path = yield* Effect.try({
+          try: () => require("path") as typeof import("path"),
+          catch: (e) => new ConversionError({ message: "Failed to load path module", cause: e }),
+        })
+
+        const resolvedInput = path.resolve(config.inputPath)
+        const resolvedOutput = path.resolve(config.outputPath)
+
+        // Check if input exists
+        const inputExists = yield* Effect.try({
+          try: () => fs.existsSync(resolvedInput),
+          catch: (e) => new ConversionError({ message: `Cannot access input: ${resolvedInput}`, cause: e }),
+        })
+
+        if (!inputExists) {
+          return yield* Effect.fail(new ConversionError({
+            message: `Input file not found: ${resolvedInput}`
+          }))
+        }
+
+        // Check if input is a directory (STL batch mode)
+        const stat = yield* Effect.try({
+          try: () => fs.statSync(resolvedInput),
+          catch: (e) => new ConversionError({ message: `Cannot stat input: ${resolvedInput}`, cause: e }),
+        })
+
+        yield* logger.info(`Converting...`)
+
+        if (stat.isDirectory()) {
+          // STL batch mode
+          const usd = defineConfig({
+            debug: config.debug,
+            ...(config.debug ? { debugOutputDir: path.dirname(resolvedOutput) } : {}),
+            upAxis: config.upAxis,
+            metersPerUnit: config.metersPerUnit,
+          })
+
+          const result = yield* Effect.tryPromise({
+            try: () => usd.convert(resolvedInput),
+            catch: (e) => new ConversionError({
+              message: `Conversion failed for directory: ${resolvedInput}`,
+              cause: e,
+            }),
+          })
+
+          // Batch mode returns multiple results handled by the framework
+          if (result instanceof Blob) {
+            const buffer = yield* Effect.tryPromise({
+              try: () => result.arrayBuffer(),
+              catch: (e) => new ConversionError({ message: "Failed to read conversion result", cause: e }),
+            })
+            yield* Effect.try({
+              try: () => fs.writeFileSync(resolvedOutput, Buffer.from(buffer)),
+              catch: (e) => new ConversionError({ message: `Failed to write output: ${resolvedOutput}`, cause: e }),
+            })
+          }
+        } else if (config.format === ".ply") {
+          // PLY uses its own converter directly
+          const inputBuffer = yield* Effect.try({
+            try: () => {
+              const buf = fs.readFileSync(resolvedInput)
+              return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+            },
+            catch: (e) => new ConversionError({ message: `Failed to read input: ${resolvedInput}`, cause: e }),
+          })
+
+          const result = yield* Effect.tryPromise({
+            try: () => convertPlyToUsdz(inputBuffer, {
+              decimateTarget: config.decimateTarget,
+              debug: config.debug,
+              ...(config.debug ? { debugOutputDir: path.dirname(resolvedOutput) } : {}),
+              upAxis: config.upAxis,
+              metersPerUnit: config.metersPerUnit,
+            }),
+            catch: (e) => new ConversionError({
+              message: `PLY conversion failed: ${resolvedInput}`,
+              cause: e,
+            }),
+          })
+
+          const buffer = yield* Effect.tryPromise({
+            try: () => result.arrayBuffer(),
+            catch: (e) => new ConversionError({ message: "Failed to read PLY conversion result", cause: e }),
+          })
+
+          yield* Effect.try({
+            try: () => fs.writeFileSync(resolvedOutput, Buffer.from(buffer)),
+            catch: (e) => new ConversionError({ message: `Failed to write output: ${resolvedOutput}`, cause: e }),
+          })
+        } else {
+          // GLB, GLTF, OBJ, FBX, STL single file
+          const usd = defineConfig({
+            debug: config.debug,
+            ...(config.debug ? { debugOutputDir: path.dirname(resolvedOutput) } : {}),
+            upAxis: config.upAxis,
+            metersPerUnit: config.metersPerUnit,
+          })
+
+          const result = yield* Effect.tryPromise({
+            try: () => usd.convert(resolvedInput),
+            catch: (e) => new ConversionError({
+              message: `Conversion failed: ${resolvedInput}`,
+              cause: e,
+            }),
+          })
+
+          const buffer = yield* Effect.tryPromise({
+            try: () => result.arrayBuffer(),
+            catch: (e) => new ConversionError({ message: "Failed to read conversion result", cause: e }),
+          })
+
+          yield* Effect.try({
+            try: () => {
+              const dir = path.dirname(resolvedOutput)
+              if (!fs.existsSync(dir)) {
+                fs.mkdirSync(dir, { recursive: true })
+              }
+              fs.writeFileSync(resolvedOutput, Buffer.from(buffer))
+            },
+            catch: (e) => new ConversionError({ message: `Failed to write output: ${resolvedOutput}`, cause: e }),
+          })
+        }
+
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+        const outputStat = yield* Effect.try({
+          try: () => fs.statSync(resolvedOutput),
+          catch: (e) => new ConversionError({ message: `Cannot stat output: ${resolvedOutput}`, cause: e }),
+        })
+        const sizeMb = (outputStat.size / 1024 / 1024).toFixed(2)
+
+        yield* logger.success(`Done in ${elapsed}s`)
+        yield* logger.success(`Output: ${resolvedOutput} (${sizeMb} MB)`)
+
+        return resolvedOutput
+      }),
+    }
+  })
+)


### PR DESCRIPTION
## Summary
- Adds `webusd` CLI using Effect TS dependency graph (Layer) pattern with 3 services: CliConfig, CliLogger, Converter
- Supports all formats (GLB, GLTF, OBJ, FBX, STL, PLY) with `--decimate`, `--debug`, `--up-axis`, `--meters-per-unit` options
- Adds rollup CLI build target (`build/cli.js`) and `bin` field to package.json

Closes #103

## Testing
- `node build/cli.js models/glb/12_animated_butterflies.glb` → 13.62 MB, passes `usdchecker --arkit`
- `node build/cli.js "models/ply/Doom combat scene.ply" --decimate 500000` → 25.36 MB, passes `usdchecker --arkit`
- `npm run type-check` and `npm run build` pass