### PR TITLE
refactor: move errors to folder, constants, inject package.json version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,36 @@ All outputs are packaged as `.usdz` with 64-byte alignment, validated against `u
 pnpm install
 ```
 
+## CLI
+
+The `webusd` CLI converts 3D models to USDZ:
+
+```shell
+webusd <input> [options]
+```
+
+**Options:**
+- `-o, --output <path>` — Output file path (default: `<input>.usdz`)
+- `-d, --debug` — Enable debug mode with intermediate files
+- `--decimate <n>` — Target face count for mesh decimation (PLY only)
+- `--up-axis <Y|Z>` — Up axis (default: Y)
+- `--meters-per-unit <n>` — Scene scale (default: 1)
+- `-h, --help` — Show help
+- `-v, --version` — Show version
+
+**Examples:**
+```shell
+webusd model.glb                           # GLB → USDZ
+webusd model.glb -o output.usdz -d        # With debug output
+webusd scan.ply --decimate 500000          # PLY with decimation
+webusd ./stl-folder/                       # STL batch mode
+```
+
+**Or use as a library:**
+```javascript
+const usdz = await usd.convert('./model.glb')
+```
+
 ## Quick Start
 
 ```javascript

--- a/src/cli/constants/constants.ts
+++ b/src/cli/constants/constants.ts
@@ -1,0 +1,33 @@
+const pkg = JSON.parse(require("fs").readFileSync(require("path").resolve(process.cwd(), "package.json"), "utf-8")) as { version: string }
+export const CLI_VERSION: string = pkg.version
+
+export const SUPPORTED_EXTENSIONS = [".glb", ".gltf", ".obj", ".fbx", ".stl", ".ply"] as const
+
+export const DEFAULT_OUTPUT_EXTENSION = ".usdz"
+
+export const HELP_TEXT = `webusd - Convert 3D models to USDZ format
+
+Usage:
+  webusd <input> [options]
+
+Arguments:
+  input                    Path to the input file (.glb, .gltf, .obj, .fbx, .stl, .ply)
+
+Options:
+  -o, --output <path>      Output file path (default: <input>.usdz)
+  -d, --debug              Enable debug mode with intermediate files
+  --decimate <n>           Target face count for mesh decimation (PLY only, 0 = off)
+  --up-axis <Y|Z>          Up axis (default: Y)
+  --meters-per-unit <n>    Scene scale (default: 1)
+  -h, --help               Show this help message
+  -v, --version            Show version
+
+Supported Formats:
+  GLB, GLTF, OBJ, FBX, STL, PLY
+
+Examples:
+  webusd model.glb
+  webusd model.glb -o output.usdz -d
+  webusd scan.ply --decimate 500000
+  webusd ./stl-folder/
+`.trim()

--- a/src/cli/constants/index.ts
+++ b/src/cli/constants/index.ts
@@ -1,0 +1,6 @@
+export {
+  CLI_VERSION,
+  SUPPORTED_EXTENSIONS,
+  DEFAULT_OUTPUT_EXTENSION,
+  HELP_TEXT,
+} from "./constants"

--- a/src/cli/errors/errors.ts
+++ b/src/cli/errors/errors.ts
@@ -1,0 +1,10 @@
+import { Data } from "effect"
+
+export class CliConfigError extends Data.TaggedError("CliConfigError")<{
+  readonly message: string
+}> {}
+
+export class ConversionError extends Data.TaggedError("ConversionError")<{
+  readonly message: string
+  readonly cause?: unknown
+}> {}

--- a/src/cli/errors/index.ts
+++ b/src/cli/errors/index.ts
@@ -1,0 +1,1 @@
+export { CliConfigError, ConversionError } from "./errors"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,13 @@
+export type { CliConfigShape } from "./services/CliConfig"
+export { CliConfig, CliConfigLive } from "./services/CliConfig"
+export type { CliLoggerShape } from "./services/CliLogger"
+export { CliLogger, CliLoggerLive } from "./services/CliLogger"
+export type { ConverterShape } from "./services/Converter"
+export { Converter, ConverterLive } from "./services/Converter"
+export type { CliConfigError, ConversionError } from "./errors"
+export {
+  CLI_VERSION,
+  SUPPORTED_EXTENSIONS,
+  DEFAULT_OUTPUT_EXTENSION,
+  HELP_TEXT,
+} from "./constants"

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,13 +1,9 @@
-/**
- * CLI Entry Point
- *
- * Composes all service layers and runs the conversion program.
- */
-
 import { Effect, Layer } from "effect"
-import { CliConfigLive, CliConfigError } from "./services/CliConfig"
+import { CliConfigLive } from "./services/CliConfig"
 import { CliLoggerLive } from "./services/CliLogger"
-import { Converter, ConverterLive, ConversionError } from "./services/Converter"
+import { Converter, ConverterLive } from "./services/Converter"
+import { CliConfigError, ConversionError } from "./errors"
+import { CLI_VERSION } from "./constants"
 
 const AppConfigLive = Layer.merge(CliConfigLive, CliLoggerLive)
 
@@ -26,7 +22,7 @@ const runnable = program.pipe(
   Effect.catchTag("CliConfigError", (e: CliConfigError) =>
     Effect.sync(() => {
       console.log(e.message)
-      process.exit(e.message.includes("Usage:") || e.message.startsWith("webusd v") ? 0 : 1)
+      process.exit(e.message.includes("Usage:") || e.message.startsWith(`webusd ${CLI_VERSION}`) ? 0 : 1)
     }),
   ),
   Effect.catchTag("ConversionError", (e: ConversionError) =>

--- a/src/cli/services/CliConfig.ts
+++ b/src/cli/services/CliConfig.ts
@@ -1,11 +1,6 @@
-/**
- * CliConfig Service
- *
- * Parses CLI arguments into a typed configuration.
- * No dependencies (Layer<CliConfig, never, never>).
- */
-
-import { Effect, Context, Layer, Data } from "effect"
+import { Effect, Context, Layer } from "effect"
+import { CliConfigError } from "../errors"
+import { CLI_VERSION, SUPPORTED_EXTENSIONS, HELP_TEXT } from "../constants"
 
 export interface CliConfigShape {
   readonly inputPath: string
@@ -22,40 +17,6 @@ export class CliConfig extends Context.Tag("CliConfig")<
   CliConfigShape
 >() {}
 
-export class CliConfigError extends Data.TaggedError("CliConfigError")<{
-  readonly message: string
-}> {}
-
-const SUPPORTED_EXTENSIONS = [".glb", ".gltf", ".obj", ".fbx", ".stl", ".ply"]
-
-const HELP_TEXT = `
-webusd - Convert 3D models to USDZ format
-
-Usage:
-  webusd <input> [options]
-
-Arguments:
-  input                    Path to the input file (.glb, .gltf, .obj, .fbx, .stl, .ply)
-
-Options:
-  -o, --output <path>      Output file path (default: <input>.usdz)
-  -d, --debug              Enable debug mode with intermediate files
-  --decimate <n>           Target face count for mesh decimation (PLY only, 0 = off)
-  --up-axis <Y|Z>          Up axis (default: Y)
-  --meters-per-unit <n>    Scene scale (default: 1)
-  -h, --help               Show this help message
-  -v, --version            Show version
-
-Supported Formats:
-  GLB, GLTF, OBJ, FBX, STL, PLY
-
-Examples:
-  webusd model.glb
-  webusd model.glb -o output.usdz -d
-  webusd scan.ply --decimate 500000
-  webusd ./stl-folder/
-`.trim()
-
 function parseArgs(argv: ReadonlyArray<string>): Effect.Effect<CliConfigShape, CliConfigError> {
   return Effect.gen(function* () {
     const args = argv.slice(2)
@@ -65,7 +26,7 @@ function parseArgs(argv: ReadonlyArray<string>): Effect.Effect<CliConfigShape, C
     }
 
     if (args.includes("-v") || args.includes("--version")) {
-      return yield* Effect.fail(new CliConfigError({ message: "webusd v1.0.0" }))
+      return yield* Effect.fail(new CliConfigError({ message: `webusd ${CLI_VERSION}` }))
     }
 
     let inputPath = ""
@@ -128,10 +89,10 @@ function parseArgs(argv: ReadonlyArray<string>): Effect.Effect<CliConfigShape, C
     }
 
     const ext = inputPath.toLowerCase().slice(inputPath.lastIndexOf("."))
-    const isDirectory = !ext || !SUPPORTED_EXTENSIONS.includes(ext)
+    const validExts = SUPPORTED_EXTENSIONS as readonly string[]
+    const isDirectory = !ext || !validExts.includes(ext)
 
-    // For directories (STL batch mode) or files, validate extension
-    if (!isDirectory && !SUPPORTED_EXTENSIONS.includes(ext)) {
+    if (!isDirectory && !validExts.includes(ext)) {
       return yield* Effect.fail(new CliConfigError({
         message: `Unsupported format: ${ext}\nSupported: ${SUPPORTED_EXTENSIONS.join(", ")}`
       }))

--- a/src/cli/services/Converter.ts
+++ b/src/cli/services/Converter.ts
@@ -1,19 +1,8 @@
-/**
- * Converter Service
- *
- * Orchestrates 3D model conversion to USDZ.
- * Depends on CliConfig and CliLogger (Layer<Converter, never, CliConfig | CliLogger>).
- */
-
-import { Effect, Context, Layer, Data } from "effect"
+import { Effect, Context, Layer } from "effect"
 import { CliConfig } from "./CliConfig"
 import { CliLogger } from "./CliLogger"
+import { ConversionError } from "../errors"
 import { defineConfig, convertPlyToUsdz } from "../../index"
-
-export class ConversionError extends Data.TaggedError("ConversionError")<{
-  readonly message: string
-  readonly cause?: unknown
-}> {}
 
 export interface ConverterShape {
   readonly run: Effect.Effect<string, ConversionError>
@@ -42,7 +31,6 @@ export const ConverterLive: Layer.Layer<Converter, never, CliConfig | CliLogger>
 
         const startTime = Date.now()
 
-        // Read input file
         const fs = yield* Effect.try({
           try: () => require("fs") as typeof import("fs"),
           catch: (e) => new ConversionError({ message: "Failed to load fs module", cause: e }),
@@ -56,7 +44,6 @@ export const ConverterLive: Layer.Layer<Converter, never, CliConfig | CliLogger>
         const resolvedInput = path.resolve(config.inputPath)
         const resolvedOutput = path.resolve(config.outputPath)
 
-        // Check if input exists
         const inputExists = yield* Effect.try({
           try: () => fs.existsSync(resolvedInput),
           catch: (e) => new ConversionError({ message: `Cannot access input: ${resolvedInput}`, cause: e }),
@@ -68,7 +55,6 @@ export const ConverterLive: Layer.Layer<Converter, never, CliConfig | CliLogger>
           }))
         }
 
-        // Check if input is a directory (STL batch mode)
         const stat = yield* Effect.try({
           try: () => fs.statSync(resolvedInput),
           catch: (e) => new ConversionError({ message: `Cannot stat input: ${resolvedInput}`, cause: e }),
@@ -77,7 +63,6 @@ export const ConverterLive: Layer.Layer<Converter, never, CliConfig | CliLogger>
         yield* logger.info(`Converting...`)
 
         if (stat.isDirectory()) {
-          // STL batch mode
           const usd = defineConfig({
             debug: config.debug,
             ...(config.debug ? { debugOutputDir: path.dirname(resolvedOutput) } : {}),
@@ -93,7 +78,6 @@ export const ConverterLive: Layer.Layer<Converter, never, CliConfig | CliLogger>
             }),
           })
 
-          // Batch mode returns multiple results handled by the framework
           if (result instanceof Blob) {
             const buffer = yield* Effect.tryPromise({
               try: () => result.arrayBuffer(),
@@ -105,7 +89,6 @@ export const ConverterLive: Layer.Layer<Converter, never, CliConfig | CliLogger>
             })
           }
         } else if (config.format === ".ply") {
-          // PLY uses its own converter directly
           const inputBuffer = yield* Effect.try({
             try: () => {
               const buf = fs.readFileSync(resolvedInput)
@@ -138,7 +121,6 @@ export const ConverterLive: Layer.Layer<Converter, never, CliConfig | CliLogger>
             catch: (e) => new ConversionError({ message: `Failed to write output: ${resolvedOutput}`, cause: e }),
           })
         } else {
-          // GLB, GLTF, OBJ, FBX, STL single file
           const usd = defineConfig({
             debug: config.debug,
             ...(config.debug ? { debugOutputDir: path.dirname(resolvedOutput) } : {}),


### PR DESCRIPTION
## Summary
- Add `src/cli/errors/` for `CliConfigError`, `ConversionError`
- Add `src/cli/constants/` with `CLI_VERSION` injected from `package.json`
- Refactor services to use new structure
- Update README.md with CLI documentation

Closes #105

## Testing
- `npm run type-check` passes
- `npm run build` passes
- `node build/cli.js --version` returns correct version
- `node build/cli.js models/glb/12_animated_butterflies.glb` works