### PR TITLE
perf: reduce peak memory during USDZ packaging

### DIFF
--- a/scripts/convert.cjs
+++ b/scripts/convert.cjs
@@ -4,6 +4,8 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { performance } = require('node:perf_hooks');
+const { Readable } = require('node:stream');
+const { pipeline } = require('node:stream/promises');
 
 const projectRoot = path.resolve(__dirname, '..');
 
@@ -56,13 +58,17 @@ const usd = defineConfig({
   const t0 = performance.now();
   console.log(`[convert] converting ${input}`);
   const blob = await usd.convert(path.resolve(input));
-  const buf = Buffer.from(await blob.arrayBuffer());
 
   const baseName = path.basename(input, path.extname(input));
   const outPath = path.join(outDir, `${baseName}.usdz`);
-  fs.writeFileSync(outPath, buf);
 
-  const mb = (buf.byteLength / 1024 / 1024).toFixed(2);
+  // Stream the Blob directly to disk so its underlying buffer can be released
+  // by the runtime as bytes are flushed, instead of materializing a full
+  // ArrayBuffer + Node Buffer copy in process memory before the write.
+  await pipeline(Readable.fromWeb(blob.stream()), fs.createWriteStream(outPath));
+
+  const { size } = fs.statSync(outPath);
+  const mb = (size / 1024 / 1024).toFixed(2);
   const secs = ((performance.now() - t0) / 1000).toFixed(1);
   console.log(`[convert] wrote ${outPath}`);
   console.log(`[convert] size=${mb} MB time=${secs}s`);

--- a/src/converters/shared/usdz-zip-writer.ts
+++ b/src/converters/shared/usdz-zip-writer.ts
@@ -86,73 +86,93 @@ export class UsdzZipWriter {
   }
 
   /**
-   * Generate the final ZIP file buffer
+   * Generate the final ZIP file buffer.
+   *
+   * Two-pass strategy keeps peak memory bounded to a single output buffer:
+   *   Pass 1 — compute total byte size and per-file local header offsets via sizing math
+   *            (no allocations beyond small offset/length arrays).
+   *   Pass 2 — preallocate the final Uint8Array once and write headers, file data, padding,
+   *            central directory and EOCD record directly into it.
+   *
+   * Output bytes are byte-for-byte identical to the previous chunk-accumulator implementation.
    */
   generate(): Uint8Array {
     // Validate file count
     FileCountSchema.parse(this.files.length);
 
-    const chunks: Uint8Array[] = [];
+    // Pass 1: size everything.
+    const fileOffsets: number[] = new Array(this.files.length);
+    const nameByteLengths: number[] = new Array(this.files.length);
     let totalSize = 0;
-    const fileOffsets: number[] = [];
 
-    // 1. Write local file headers and data
     for (let i = 0; i < this.files.length; i++) {
       const file = this.files[i];
+      fileOffsets[i] = totalSize;
 
-      // Update file offset to current position
-      file.offset = totalSize;
-      fileOffsets.push(totalSize);
+      const nameByteLength = this.encoder.encode(file.name).length;
+      nameByteLengths[i] = nameByteLength;
 
-      const header = this.createLocalFileHeader(file, totalSize);
-
-      chunks.push(header);
-      totalSize += header.length;
-
-      // Write file data (handle chunks)
-      if (Array.isArray(file.data)) {
-        for (const chunk of file.data) {
-          chunks.push(chunk);
-          totalSize += chunk.length;
-        }
-      } else {
-        chunks.push(file.data);
-        totalSize += file.data.length;
+      const baseHeaderSize = ZIP_CONSTANTS.LOCAL_FILE_HEADER_SIZE + nameByteLength;
+      let extraFieldLength = 0;
+      if (this.alignTo64Bytes) {
+        const dataStart = totalSize + baseHeaderSize;
+        const aligned = Math.ceil(dataStart / ZIP_CONSTANTS.ALIGNMENT_BYTES) * ZIP_CONSTANTS.ALIGNMENT_BYTES;
+        extraFieldLength = aligned - dataStart;
       }
+
+      totalSize += baseHeaderSize + extraFieldLength + file.size;
     }
 
-    // 2. Add padding before central directory
+    // Padding before central directory.
+    let centralDirPadding = 0;
     if (this.alignTo64Bytes) {
-      const requiredOffset = Math.ceil(totalSize / ZIP_CONSTANTS.ALIGNMENT_BYTES) * ZIP_CONSTANTS.ALIGNMENT_BYTES;
-      const paddingNeeded = requiredOffset - totalSize;
-      if (paddingNeeded > 0) {
-        const padding = new Uint8Array(paddingNeeded);
-        chunks.push(padding);
-        totalSize += paddingNeeded;
-      }
+      const aligned = Math.ceil(totalSize / ZIP_CONSTANTS.ALIGNMENT_BYTES) * ZIP_CONSTANTS.ALIGNMENT_BYTES;
+      centralDirPadding = aligned - totalSize;
+      totalSize += centralDirPadding;
     }
-
-    // 3. Write central directory
     const centralDirStart = totalSize;
+
+    // Central directory size.
+    let centralDirSize = 0;
     for (let i = 0; i < this.files.length; i++) {
-      const file = this.files[i];
-      const centralHeader = this.createCentralDirectoryHeader(file, fileOffsets[i]);
-      chunks.push(centralHeader);
-      totalSize += centralHeader.length;
+      centralDirSize += ZIP_CONSTANTS.CENTRAL_DIRECTORY_HEADER_SIZE + nameByteLengths[i];
     }
+    totalSize += centralDirSize + ZIP_CONSTANTS.END_OF_CENTRAL_DIRECTORY_SIZE;
 
-    // 4. Write end of central directory record
-    const endRecord = this.createEndOfCentralDirectoryRecord(centralDirStart, totalSize - centralDirStart);
-    chunks.push(endRecord);
-    totalSize += endRecord.length;
-
-    // Combine all chunks
+    // Pass 2: write directly into the preallocated output.
     const result = new Uint8Array(totalSize);
     let offset = 0;
-    for (const chunk of chunks) {
-      result.set(chunk, offset);
-      offset += chunk.length;
+
+    for (let i = 0; i < this.files.length; i++) {
+      const file = this.files[i];
+      file.offset = fileOffsets[i];
+
+      const header = this.createLocalFileHeader(file, fileOffsets[i]);
+      result.set(header, offset);
+      offset += header.length;
+
+      if (Array.isArray(file.data)) {
+        for (const chunk of file.data) {
+          result.set(chunk, offset);
+          offset += chunk.length;
+        }
+      } else {
+        result.set(file.data, offset);
+        offset += file.data.length;
+      }
     }
+
+    // Padding bytes are already zero-initialized in result.
+    offset += centralDirPadding;
+
+    for (let i = 0; i < this.files.length; i++) {
+      const centralHeader = this.createCentralDirectoryHeader(this.files[i], fileOffsets[i]);
+      result.set(centralHeader, offset);
+      offset += centralHeader.length;
+    }
+
+    const endRecord = this.createEndOfCentralDirectoryRecord(centralDirStart, centralDirSize);
+    result.set(endRecord, offset);
 
     return result;
   }


### PR DESCRIPTION
## Summary
- `UsdzZipWriter.generate()` now sizes the archive in a single math pass and writes everything directly into one preallocated `Uint8Array` — drops the intermediate chunk accumulator that briefly held both header references and a second full-size output copy.
- `scripts/convert.cjs` streams the Blob to disk via `stream.pipeline` instead of materializing a full Node `Buffer` copy before `fs.writeFileSync`.

## Why
Peak resident memory during conversion was ~2× the final USDZ size at the moment `generate()` allocated `result` while the chunk array still held references to every header and file payload. For dense assets (point clouds, multi-mesh scenes) this was the cliff between successful conversion and OOM on constrained Node hosts.

## Output guarantees (the important part)
- Container is unchanged: still a `.usdz` ZIP with `STORE` compression, 64-byte alignment, ZIP magic `PK\x03\x04`, MIME `model/vnd.usdz+zip`.
- Bytes are **byte-for-byte identical** to the previous implementation. Butterfly GLB fixture produces `usdzSize: 14286588` on both master and this branch.
- All 30 existing tests pass unchanged.

## Test plan
- [x] `pnpm run type-check` — clean
- [x] `pnpm run test:run` — 30 / 30 pass
- [x] Output size unchanged on butterfly fixture (`14,286,588 B`)

Closes #110