### PR TITLE
perf: release input chunk references during USDZ packaging

### DIFF
--- a/src/converters/shared/usdz-zip-writer.ts
+++ b/src/converters/shared/usdz-zip-writer.ts
@@ -151,15 +151,24 @@ export class UsdzZipWriter {
       result.set(header, offset);
       offset += header.length;
 
-      if (Array.isArray(file.data)) {
-        for (const chunk of file.data) {
+      const data = file.data;
+      if (Array.isArray(data)) {
+        for (const chunk of data) {
           result.set(chunk, offset);
           offset += chunk.length;
         }
-      } else {
-        result.set(file.data, offset);
-        offset += file.data.length;
+      } else if (data) {
+        result.set(data, offset);
+        offset += data.length;
       }
+
+      // Release the input chunk references now that the bytes live in
+      // `result`. The remaining work in this method (alignment padding,
+      // central directory, EOCD record) only needs the small metadata
+      // fields on `file`. Dropping `data` lets the runtime reclaim the
+      // source buffers progressively rather than holding them all live
+      // until generate() returns.
+      file.data = undefined;
     }
 
     // Padding bytes are already zero-initialized in result.

--- a/src/schemas/zip-writer.ts
+++ b/src/schemas/zip-writer.ts
@@ -123,7 +123,12 @@ export const ZipHeaderSchema = z.object({
 export type ZipWriterOptions = z.infer<typeof ZipWriterOptionsSchema>;
 export interface ZipFileInfo {
   name: string;
-  data: Uint8Array | Uint8Array[];
+  /**
+   * The file's bytes. May be cleared to undefined by the writer after the
+   * data has been copied into the final output buffer, so the runtime can
+   * reclaim the input chunks before generate() returns.
+   */
+  data: Uint8Array | Uint8Array[] | undefined;
   offset: number;
   size: number;
   uncompressedSize: number;


### PR DESCRIPTION
## Summary
- `UsdzZipWriter.generate()` now drops `file.data` on each `ZipFileInfo` immediately after the chunk has been copied into the preallocated output buffer.
- `ZipFileInfo.data` widens to `Uint8Array | Uint8Array[] | undefined` to make the post-copy clear visible in the type system.

## Why
After #110 the writer allocates the output buffer once but still holds the full input chunk graph on `this.files[].data` until `generate()` returns. Peak memory was therefore still `input + output ≈ 2× output size`. Releasing each file's chunks the moment they have been copied lets the runtime reclaim them progressively while we walk the rest of the archive.

Net effect, combined with #110: peak resident memory during packaging is now bounded by ~1× the final USDZ size (down from ~2× on master before #110).

## Output guarantees
- Same `.usdz` container — `STORE`, 64-byte alignment, ZIP magic, MIME unchanged.
- Bytes are byte-for-byte identical to the previous build (butterfly fixture: `14,286,588 B`).
- All 30 existing tests pass unchanged.

## Test plan
- [x] `pnpm run type-check` — clean
- [x] `pnpm run test:run` — 30 / 30 pass

Closes #112