### PR TITLE
feat: scaffold USDC (Crate) writer — bootstrap header + TOC

### DIFF
--- a/src/__tests__/usdc-writer.test.ts
+++ b/src/__tests__/usdc-writer.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Byte-level unit tests for the USDC (Crate) writer scaffold.
+ *
+ * These assertions are intentionally low-level: they pin the exact bytes
+ * emitted by `writeBootstrap` and `writeTOC` so any future change to the
+ * format primitives must be deliberate and visible in this file.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  USDC_BOOTSTRAP_SIZE,
+  USDC_DEFAULT_VERSION,
+  USDC_MAGIC,
+  USDC_SECTION_NAME_SIZE,
+  USDC_TOC_ENTRY_SIZE,
+  tocByteLength,
+  writeBootstrap,
+  writeTOC,
+} from '../converters/shared/usdc-writer';
+
+const MAGIC_STRING = 'PXR-USDC';
+
+describe('USDC writer — bootstrap header', () => {
+  it('is exactly 88 bytes', () => {
+    expect(USDC_BOOTSTRAP_SIZE).toBe(88);
+  });
+
+  it('writes the PXR-USDC magic at the start', () => {
+    const buf = new Uint8Array(USDC_BOOTSTRAP_SIZE);
+    const view = new DataView(buf.buffer);
+
+    writeBootstrap(view, 0, /* tocOffset */ 0);
+
+    expect(Array.from(buf.subarray(0, 8))).toEqual(Array.from(USDC_MAGIC));
+    expect(new TextDecoder('ascii').decode(buf.subarray(0, 8))).toBe(MAGIC_STRING);
+  });
+
+  it('writes the version triple followed by five zero bytes', () => {
+    const buf = new Uint8Array(USDC_BOOTSTRAP_SIZE);
+    const view = new DataView(buf.buffer);
+
+    writeBootstrap(view, 0, 0, { major: 1, minor: 2, patch: 3 });
+
+    expect(buf[8]).toBe(1);
+    expect(buf[9]).toBe(2);
+    expect(buf[10]).toBe(3);
+    expect(Array.from(buf.subarray(11, 16))).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it('writes the default version (0.8.0) when none is supplied', () => {
+    const buf = new Uint8Array(USDC_BOOTSTRAP_SIZE);
+    const view = new DataView(buf.buffer);
+
+    writeBootstrap(view, 0, 0);
+
+    expect(buf[8]).toBe(USDC_DEFAULT_VERSION.major);
+    expect(buf[9]).toBe(USDC_DEFAULT_VERSION.minor);
+    expect(buf[10]).toBe(USDC_DEFAULT_VERSION.patch);
+  });
+
+  it('writes tocOffset as a little-endian int64 at byte 16', () => {
+    const buf = new Uint8Array(USDC_BOOTSTRAP_SIZE);
+    const view = new DataView(buf.buffer);
+    const tocOffset = 0x0011_2233_4455; // arbitrary 6-byte value
+
+    writeBootstrap(view, 0, tocOffset);
+
+    expect(view.getBigInt64(16, /* littleEndian */ true)).toBe(BigInt(tocOffset));
+    // Independent verification: rebuild the same value byte-by-byte.
+    const lo = buf[16] | (buf[17] << 8) | (buf[18] << 16) | (buf[19] << 24);
+    const hi = buf[20] | (buf[21] << 8) | (buf[22] << 16) | (buf[23] << 24);
+    expect(lo >>> 0).toBe(tocOffset & 0xffff_ffff);
+    expect(hi >>> 0).toBe(Math.floor(tocOffset / 2 ** 32));
+  });
+
+  it('zero-fills the 64-byte reserved region even when the buffer is dirty', () => {
+    const buf = new Uint8Array(USDC_BOOTSTRAP_SIZE).fill(0xff);
+    const view = new DataView(buf.buffer);
+
+    writeBootstrap(view, 0, 0);
+
+    for (let i = 24; i < USDC_BOOTSTRAP_SIZE; i++) {
+      expect(buf[i]).toBe(0);
+    }
+  });
+
+  it('returns the byte offset immediately after the bootstrap', () => {
+    const buf = new Uint8Array(USDC_BOOTSTRAP_SIZE * 2);
+    const view = new DataView(buf.buffer);
+
+    expect(writeBootstrap(view, 0, 0)).toBe(USDC_BOOTSTRAP_SIZE);
+    expect(writeBootstrap(view, USDC_BOOTSTRAP_SIZE, 0)).toBe(USDC_BOOTSTRAP_SIZE * 2);
+  });
+
+  it('honours non-zero offsets', () => {
+    const buf = new Uint8Array(USDC_BOOTSTRAP_SIZE + 16).fill(0xee);
+    const view = new DataView(buf.buffer);
+
+    writeBootstrap(view, 16, /* tocOffset */ 0x42);
+
+    // Bytes before the offset are untouched.
+    for (let i = 0; i < 16; i++) {
+      expect(buf[i]).toBe(0xee);
+    }
+    expect(new TextDecoder('ascii').decode(buf.subarray(16, 24))).toBe(MAGIC_STRING);
+    expect(view.getBigInt64(16 + 16, true)).toBe(0x42n);
+  });
+
+  it('throws when the write would overflow the buffer', () => {
+    const tooSmall = new DataView(new ArrayBuffer(USDC_BOOTSTRAP_SIZE - 1));
+    expect(() => writeBootstrap(tooSmall, 0, 0)).toThrow(/out of bounds/);
+  });
+
+  it('throws on negative or non-integer tocOffset', () => {
+    const view = new DataView(new ArrayBuffer(USDC_BOOTSTRAP_SIZE));
+    expect(() => writeBootstrap(view, 0, -1)).toThrow(/non-negative integer/);
+    expect(() => writeBootstrap(view, 0, 1.5)).toThrow(/non-negative integer/);
+  });
+});
+
+describe('USDC writer — TOC', () => {
+  it('reports correct byte length for empty and non-empty TOCs', () => {
+    expect(USDC_TOC_ENTRY_SIZE).toBe(32);
+    expect(tocByteLength(0)).toBe(8);
+    expect(tocByteLength(1)).toBe(8 + 32);
+    expect(tocByteLength(7)).toBe(8 + 7 * 32);
+  });
+
+  it('rejects invalid section counts', () => {
+    expect(() => tocByteLength(-1)).toThrow();
+    expect(() => tocByteLength(1.5)).toThrow();
+  });
+
+  it('writes the section count as a little-endian uint64', () => {
+    const sections = [
+      { name: 'TOKENS', start: 100, size: 32 },
+      { name: 'STRINGS', start: 132, size: 16 },
+      { name: 'FIELDS', start: 148, size: 64 },
+    ];
+    const total = tocByteLength(sections.length);
+    const view = new DataView(new ArrayBuffer(total));
+
+    writeTOC(view, 0, sections);
+
+    expect(view.getBigUint64(0, /* littleEndian */ true)).toBe(BigInt(sections.length));
+  });
+
+  it('encodes each section as { char[16] name, int64 start, int64 size } little-endian', () => {
+    const sections = [
+      { name: 'TOKENS', start: 0x1122_3344, size: 0x55 },
+      { name: 'PATHS', start: 0x6677_8899, size: 0xaabb },
+    ];
+    const view = new DataView(new ArrayBuffer(tocByteLength(sections.length)));
+
+    writeTOC(view, 0, sections);
+
+    let cursor = 8;
+    for (const expected of sections) {
+      const nameBytes = new Uint8Array(view.buffer, cursor, USDC_SECTION_NAME_SIZE);
+      const nullIdx = nameBytes.indexOf(0);
+      const decodedName = new TextDecoder('ascii').decode(
+        nameBytes.subarray(0, nullIdx === -1 ? USDC_SECTION_NAME_SIZE : nullIdx)
+      );
+      expect(decodedName).toBe(expected.name);
+
+      // Bytes after the name terminator must be zero (zero-padded section).
+      for (let i = expected.name.length; i < USDC_SECTION_NAME_SIZE; i++) {
+        expect(nameBytes[i]).toBe(0);
+      }
+      cursor += USDC_SECTION_NAME_SIZE;
+
+      expect(view.getBigInt64(cursor, true)).toBe(BigInt(expected.start));
+      cursor += 8;
+
+      expect(view.getBigInt64(cursor, true)).toBe(BigInt(expected.size));
+      cursor += 8;
+    }
+  });
+
+  it('truncates section names longer than 15 bytes and keeps a null terminator', () => {
+    const longName = 'A_VERY_LONG_SECTION_NAME';
+    const sections = [{ name: longName, start: 0, size: 0 }];
+    const view = new DataView(new ArrayBuffer(tocByteLength(1)));
+
+    writeTOC(view, 0, sections);
+
+    const nameBytes = new Uint8Array(view.buffer, 8, USDC_SECTION_NAME_SIZE);
+    expect(nameBytes[USDC_SECTION_NAME_SIZE - 1]).toBe(0);
+    expect(new TextDecoder('ascii').decode(nameBytes.subarray(0, USDC_SECTION_NAME_SIZE - 1))).toBe(
+      longName.slice(0, USDC_SECTION_NAME_SIZE - 1)
+    );
+  });
+
+  it('rejects non-ASCII section names without writing any bytes', () => {
+    const buf = new Uint8Array(tocByteLength(1)).fill(0xee);
+    const view = new DataView(buf.buffer);
+
+    expect(() =>
+      writeTOC(view, 0, [{ name: 'ÜNICODE', start: 0, size: 0 }])
+    ).toThrow(/non-ASCII/);
+
+    // Buffer must remain entirely untouched on validation failure.
+    for (const b of buf) {
+      expect(b).toBe(0xee);
+    }
+  });
+
+  it('rejects negative start or size', () => {
+    const view = new DataView(new ArrayBuffer(tocByteLength(1)));
+    expect(() => writeTOC(view, 0, [{ name: 'X', start: -1, size: 0 }])).toThrow(/invalid start/);
+    expect(() => writeTOC(view, 0, [{ name: 'X', start: 0, size: -1 }])).toThrow(/invalid size/);
+  });
+
+  it('throws when the write would overflow the buffer', () => {
+    const sections = [{ name: 'TOKENS', start: 0, size: 0 }];
+    const tooSmall = new DataView(new ArrayBuffer(tocByteLength(sections.length) - 1));
+    expect(() => writeTOC(tooSmall, 0, sections)).toThrow(/out of bounds/);
+  });
+
+  it('returns the byte offset immediately after the TOC', () => {
+    const sections = [
+      { name: 'TOKENS', start: 0, size: 0 },
+      { name: 'PATHS', start: 0, size: 0 },
+    ];
+    const total = tocByteLength(sections.length);
+    const view = new DataView(new ArrayBuffer(total + 16));
+
+    expect(writeTOC(view, 0, sections)).toBe(total);
+    expect(writeTOC(view, 16, sections)).toBe(16 + total);
+  });
+});
+
+describe('USDC writer — bootstrap + TOC compose end-to-end', () => {
+  it('produces a buffer whose tocOffset points at a readable TOC', () => {
+    const sections = [
+      { name: 'TOKENS', start: USDC_BOOTSTRAP_SIZE + 0, size: 0 },
+      { name: 'STRINGS', start: USDC_BOOTSTRAP_SIZE + 0, size: 0 },
+    ];
+    const tocLen = tocByteLength(sections.length);
+    const tocOffset = USDC_BOOTSTRAP_SIZE; // toc immediately follows bootstrap
+    const buf = new Uint8Array(USDC_BOOTSTRAP_SIZE + tocLen);
+    const view = new DataView(buf.buffer);
+
+    writeBootstrap(view, 0, tocOffset);
+    writeTOC(view, tocOffset, sections);
+
+    // Re-read the tocOffset from the bootstrap and use it to find the count.
+    const readTocOffset = Number(view.getBigInt64(16, true));
+    expect(readTocOffset).toBe(tocOffset);
+    expect(view.getBigUint64(readTocOffset, true)).toBe(BigInt(sections.length));
+  });
+});

--- a/src/converters/shared/usdc-writer.ts
+++ b/src/converters/shared/usdc-writer.ts
@@ -1,0 +1,217 @@
+/** WebUsdFramework.Converters.Shared.UsdcWriter — Pixar Crate (USDC) binary layer encoder
+ *
+ * SCAFFOLD ONLY. This module provides the container-level building blocks for
+ * USDC ("Crate") layer files: the 88-byte bootstrap header and the table-of-
+ * contents structure. The actual section encoders (TOKENS, STRINGS, FIELDS,
+ * FIELDSETS, PATHS, SPECS), ValueRep encoding, and LZ4 array compression are
+ * intentionally NOT included — they will land in subsequent PRs that build on
+ * this foundation.
+ *
+ * The functions in this module are pure: no I/O, no allocation beyond the
+ * caller-provided DataView. The module is currently exported but NOT wired
+ * into the converter pipeline.
+ *
+ * Reference: `pxr/usd/usd/crateFile.{h,cpp}` from the OpenUSD source tree.
+ */
+
+/**
+ * Magic identifier at the start of every USDC file: ASCII `PXR-USDC`.
+ */
+export const USDC_MAGIC: ReadonlyArray<number> = Object.freeze([
+  0x50, 0x58, 0x52, 0x2d, 0x55, 0x53, 0x44, 0x43, // 'P','X','R','-','U','S','D','C'
+]);
+
+/**
+ * Total byte length of the bootstrap header.
+ *
+ * Layout:
+ *   [ 0 ..  8) ident       — `PXR-USDC` magic
+ *   [ 8 .. 16) version     — `[major, minor, patch, 0, 0, 0, 0, 0]`
+ *   [16 .. 24) tocOffset   — int64 little-endian (file offset to the TOC)
+ *   [24 .. 88) reserved    — 64 bytes, zero-filled
+ */
+export const USDC_BOOTSTRAP_SIZE = 88;
+
+/**
+ * Number of bytes a TOC section name occupies, including the trailing null
+ * terminator. Section names longer than 15 characters will be truncated.
+ */
+export const USDC_SECTION_NAME_SIZE = 16;
+
+/**
+ * Byte length of a single TOC section entry:
+ *   { name[16], start: int64, size: int64 }
+ */
+export const USDC_TOC_ENTRY_SIZE = USDC_SECTION_NAME_SIZE + 8 + 8;
+
+/**
+ * Pixar Crate file format version targeted by this writer.
+ *
+ * The default is conservative (0.8.0) so the foundation works with the widest
+ * range of USD readers. Subsequent PRs that add ValueRep coverage may bump the
+ * default if they introduce features that require a newer version.
+ */
+export interface UsdcVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+export const USDC_DEFAULT_VERSION: Readonly<UsdcVersion> = Object.freeze({
+  major: 0,
+  minor: 8,
+  patch: 0,
+});
+
+/**
+ * Description of one section in the table of contents.
+ */
+export interface UsdcSection {
+  /** ASCII section name, e.g. `TOKENS`, `STRINGS`, `FIELDS`. Max 15 chars. */
+  name: string;
+  /** Absolute byte offset of the section's payload from the start of the file. */
+  start: number;
+  /** Byte length of the section's payload as it appears on disk. */
+  size: number;
+}
+
+/**
+ * Write the 88-byte bootstrap header starting at `offset` in `view`.
+ *
+ * The caller owns the underlying buffer and must ensure `view` has at least
+ * `offset + USDC_BOOTSTRAP_SIZE` bytes available. The function performs no
+ * allocation.
+ *
+ * @returns The byte offset immediately after the bootstrap (`offset + 88`).
+ * @throws RangeError if the write would fall outside `view`.
+ */
+export function writeBootstrap(
+  view: DataView,
+  offset: number,
+  tocOffset: number,
+  version: UsdcVersion = USDC_DEFAULT_VERSION
+): number {
+  if (offset < 0 || offset + USDC_BOOTSTRAP_SIZE > view.byteLength) {
+    throw new RangeError(
+      `writeBootstrap: out of bounds (need ${USDC_BOOTSTRAP_SIZE} bytes at offset ${offset}, have ${view.byteLength - offset})`
+    );
+  }
+  if (tocOffset < 0 || !Number.isInteger(tocOffset)) {
+    throw new RangeError(`writeBootstrap: tocOffset must be a non-negative integer (got ${tocOffset})`);
+  }
+
+  // Magic: "PXR-USDC"
+  for (let i = 0; i < USDC_MAGIC.length; i++) {
+    view.setUint8(offset + i, USDC_MAGIC[i]);
+  }
+
+  // Version: [major, minor, patch, 0, 0, 0, 0, 0]
+  view.setUint8(offset + 8, version.major & 0xff);
+  view.setUint8(offset + 9, version.minor & 0xff);
+  view.setUint8(offset + 10, version.patch & 0xff);
+  view.setUint8(offset + 11, 0);
+  view.setUint8(offset + 12, 0);
+  view.setUint8(offset + 13, 0);
+  view.setUint8(offset + 14, 0);
+  view.setUint8(offset + 15, 0);
+
+  // tocOffset: int64 little-endian
+  view.setBigInt64(offset + 16, BigInt(tocOffset), /* littleEndian */ true);
+
+  // Reserved 64 bytes. Zeroed even when the caller hands us a non-zeroed view.
+  for (let i = 24; i < USDC_BOOTSTRAP_SIZE; i++) {
+    view.setUint8(offset + i, 0);
+  }
+
+  return offset + USDC_BOOTSTRAP_SIZE;
+}
+
+/**
+ * Compute the total byte length of a TOC for a given number of sections.
+ *
+ * Layout:
+ *   uint64 numSections
+ *   numSections × { char[16] name, int64 start, int64 size }
+ */
+export function tocByteLength(sectionCount: number): number {
+  if (sectionCount < 0 || !Number.isInteger(sectionCount)) {
+    throw new RangeError(`tocByteLength: sectionCount must be a non-negative integer (got ${sectionCount})`);
+  }
+  return 8 + sectionCount * USDC_TOC_ENTRY_SIZE;
+}
+
+/**
+ * Write the table-of-contents starting at `offset` in `view`.
+ *
+ * Layout written:
+ *   uint64 little-endian: numSections
+ *   for each section:
+ *     char[16]:            section name, ASCII, null-padded to 16 bytes
+ *     int64 little-endian: start
+ *     int64 little-endian: size
+ *
+ * @returns The byte offset immediately after the TOC.
+ * @throws RangeError if the write would fall outside `view`, if a section
+ *   name contains non-ASCII characters, or if a section has a negative
+ *   `start` or `size`.
+ */
+export function writeTOC(
+  view: DataView,
+  offset: number,
+  sections: ReadonlyArray<UsdcSection>
+): number {
+  const required = tocByteLength(sections.length);
+  if (offset < 0 || offset + required > view.byteLength) {
+    throw new RangeError(
+      `writeTOC: out of bounds (need ${required} bytes at offset ${offset}, have ${view.byteLength - offset})`
+    );
+  }
+
+  // Validate every section before emitting any bytes so a partial write
+  // cannot leave a half-encoded TOC in the buffer.
+  const nameMax = USDC_SECTION_NAME_SIZE - 1;
+  for (const section of sections) {
+    if (!Number.isInteger(section.start) || section.start < 0) {
+      throw new RangeError(
+        `writeTOC: section "${section.name}" has invalid start ${section.start} (must be a non-negative integer)`
+      );
+    }
+    if (!Number.isInteger(section.size) || section.size < 0) {
+      throw new RangeError(
+        `writeTOC: section "${section.name}" has invalid size ${section.size} (must be a non-negative integer)`
+      );
+    }
+    const nameLen = Math.min(section.name.length, nameMax);
+    for (let i = 0; i < nameLen; i++) {
+      const code = section.name.charCodeAt(i);
+      if (code < 0x20 || code > 0x7e) {
+        throw new RangeError(
+          `writeTOC: section name "${section.name}" contains non-ASCII char at position ${i}`
+        );
+      }
+    }
+  }
+
+  // numSections (uint64 little-endian)
+  view.setBigUint64(offset, BigInt(sections.length), /* littleEndian */ true);
+  let cursor = offset + 8;
+
+  for (const section of sections) {
+    // name: up to 15 ASCII bytes, null-terminated, zero-padded to 16 bytes
+    for (let i = 0; i < USDC_SECTION_NAME_SIZE; i++) {
+      const ch = i < section.name.length && i < nameMax ? section.name.charCodeAt(i) : 0;
+      view.setUint8(cursor + i, ch & 0xff);
+    }
+    cursor += USDC_SECTION_NAME_SIZE;
+
+    // start (int64 little-endian)
+    view.setBigInt64(cursor, BigInt(section.start), true);
+    cursor += 8;
+
+    // size (int64 little-endian)
+    view.setBigInt64(cursor, BigInt(section.size), true);
+    cursor += 8;
+  }
+
+  return cursor;
+}


### PR DESCRIPTION
## Summary
- New module `src/converters/shared/usdc-writer.ts` with the container-level building blocks of the Pixar Crate (USDC) layer format: 88-byte bootstrap header writer + table-of-contents writer + sizing helper.
- 20 new byte-level unit tests in `src/__tests__/usdc-writer.test.ts` that pin the exact bytes emitted, version encoding, name truncation, validation rules, and round-trip composition of bootstrap → TOC.

## Why
The framework's USDA-only output is text-heavy: float arrays for points / normals / UVs are ASCII-encoded one number per call, which is large and dominates archive size and packaging memory for dense geometry (point clouds, multi-mesh scenes). Pixar's binary Crate format with LZ4-compressed array `ValueRep`s typically produces **5–10× smaller geometry layers**. To get there we need a USDC writer.

This PR is the foundation only. It does **not** wire into the converter pipeline yet. That happens in follow-up PRs that add the section encoders (TOKENS / STRINGS / FIELDS / FIELDSETS / PATHS / SPECS), `ValueRep` encoding, LZ4 array compression, and finally the integration in `usd-packaging.ts` / `usd-hierarchy-builder.ts`.

## Output guarantees
- Outer container remains `.usdz` — STORE / 64-byte aligned / `PK\x03\x04` magic / `model/vnd.usdz+zip` MIME.
- No behavioural change to any converter — the new module is exported but unused at runtime in this PR.
- Existing GLB→USDZ output bytes are byte-for-byte identical (butterfly fixture: `14,286,588 B`).

## Format pinning (this is the part to scrutinise)
The writers are validated against the canonical OpenUSD layout from `pxr/usd/usd/crateFile.{h,cpp}`:

| Bytes | Field | Encoding |
|---|---|---|
| 0–7 | `ident` | ASCII `PXR-USDC` |
| 8–15 | `version` | `[major, minor, patch, 0, 0, 0, 0, 0]` |
| 16–23 | `tocOffset` | int64 little-endian |
| 24–87 | `_reserved[8]` | 64 zero bytes |

TOC layout: `uint64 numSections` (LE) followed by `numSections × { char[16] name, int64 start, int64 size }` (LE).

Default version is conservative `0.8.0` so the foundation works with the widest range of USD readers; later PRs may bump it as new ValueReps require.

## Test plan
- [x] `pnpm run type-check` — clean
- [x] `pnpm run test:run` — 50 / 50 pass (20 new + 30 existing)
- [x] Existing GLB→USDZ output bytes unchanged (`14,286,588 B`)

Closes #114