### PR TITLE
feat: end-to-end streaming through every converter (#120)

### DIFF
--- a/scripts/convert.cjs
+++ b/scripts/convert.cjs
@@ -4,8 +4,6 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { performance } = require('node:perf_hooks');
-const { Readable } = require('node:stream');
-const { pipeline } = require('node:stream/promises');
 
 const projectRoot = path.resolve(__dirname, '..');
 
@@ -57,21 +55,20 @@ const usd = defineConfig({
 (async () => {
   const t0 = performance.now();
   console.log(`[convert] converting ${input}`);
-  const blob = await usd.convert(path.resolve(input));
 
   const baseName = path.basename(input, path.extname(input));
   const outPath = path.join(outDir, `${baseName}.usdz`);
 
-  // Stream the Blob directly to disk so its underlying buffer can be released
-  // by the runtime as bytes are flushed, instead of materializing a full
-  // ArrayBuffer + Node Buffer copy in process memory before the write.
-  await pipeline(Readable.fromWeb(blob.stream()), fs.createWriteStream(outPath));
+  // Use the framework's streaming output path. The archive is streamed
+  // directly to disk inside the converter — peak memory is bounded by the
+  // largest single file in the archive instead of the total archive size,
+  // and the script never materializes a full Blob.
+  const result = await usd.convert(path.resolve(input), { outputPath: outPath });
 
-  const { size } = fs.statSync(outPath);
-  const mb = (size / 1024 / 1024).toFixed(2);
+  const mb = (result.totalBytes / 1024 / 1024).toFixed(2);
   const secs = ((performance.now() - t0) / 1000).toFixed(1);
   console.log(`[convert] wrote ${outPath}`);
-  console.log(`[convert] size=${mb} MB time=${secs}s`);
+  console.log(`[convert] size=${mb} MB time=${secs}s files=${result.fileCount}`);
 
   // Final line: absolute path, consumed by validate-usdz.sh
   console.log(outPath);

--- a/src/__tests__/converter-streaming.test.ts
+++ b/src/__tests__/converter-streaming.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Per-converter byte-equivalence tests for the streaming output path.
+ *
+ * For each supported format (GLB, PLY, OBJ, STL) the streaming call
+ *   convertXxxToUsdz(input, config, { outputPath })
+ * must write bytes that are byte-for-byte identical to the in-memory buffered
+ * call
+ *   convertXxxToUsdz(input, config)  // → Blob
+ *
+ * Both invocations stamp `new Date()` into ZIP local/central-directory headers.
+ * The system clock is pinned with `vi.setSystemTime` so those timestamps
+ * are identical across both calls.
+ *
+ * GLB tests require the butterfly fixture; they are skipped automatically when
+ * the file is absent (CI environments without large fixtures).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { convertGlbToUsdz } from '../converters/gltf';
+import { convertPlyToUsdz } from '../converters/ply/ply-converter';
+import { convertObjToUsdz } from '../converters/obj/obj-converter';
+import { convertStlToUsdz } from '../converters/stl/stl-converter';
+
+// ─── Fixture paths ────────────────────────────────────────────────────────────
+
+const BUTTERFLY_GLB = path.resolve(__dirname, '../../models/glb/12_animated_butterflies.glb');
+const hasButterfly = fs.existsSync(BUTTERFLY_GLB);
+
+// ─── Synthetic minimal inputs ─────────────────────────────────────────────────
+
+/** ASCII PLY point cloud — 3 vertices, no faces. */
+function makeMinimalPly(): ArrayBuffer {
+  const text = [
+    'ply',
+    'format ascii 1.0',
+    'element vertex 3',
+    'property float x',
+    'property float y',
+    'property float z',
+    'end_header',
+    '0.0 0.0 0.0',
+    '1.0 0.0 0.0',
+    '0.0 1.0 0.0',
+    '',
+  ].join('\n');
+  return new TextEncoder().encode(text).buffer as ArrayBuffer;
+}
+
+/** OBJ mesh — single triangle. */
+function makeMinimalObj(): ArrayBuffer {
+  const text = 'v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n';
+  return new TextEncoder().encode(text).buffer as ArrayBuffer;
+}
+
+/**
+ * Binary STL — one triangle.
+ * Layout: 80-byte header | uint32 count=1 | normal(f32×3) | v0,v1,v2(f32×3 each) | attr(u16)
+ */
+function makeMinimalStl(): ArrayBuffer {
+  const buf = new ArrayBuffer(134); // 80 + 4 + 50
+  const v = new DataView(buf);
+  v.setUint32(80, 1, true);        // triangle count
+  v.setFloat32(84, 0, true);       // normal x
+  v.setFloat32(88, 0, true);       // normal y
+  v.setFloat32(92, 1, true);       // normal z
+  v.setFloat32(96, 0, true);       // v0 x
+  v.setFloat32(100, 0, true);      // v0 y
+  v.setFloat32(104, 0, true);      // v0 z
+  v.setFloat32(108, 1, true);      // v1 x
+  v.setFloat32(112, 0, true);      // v1 y
+  v.setFloat32(116, 0, true);      // v1 z
+  v.setFloat32(120, 0, true);      // v2 x
+  v.setFloat32(124, 1, true);      // v2 y
+  v.setFloat32(128, 0, true);      // v2 z
+  v.setUint16(132, 0, true);       // attribute byte count
+  return buf;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function blobToBytes(blob: Blob): Promise<Uint8Array> {
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
+/**
+ * Create a temp file path, run `fn`, then unlink regardless of outcome.
+ * Uses Math.random() so the name is unique even with a pinned fake clock.
+ */
+async function withTmp(fn: (p: string) => Promise<void>): Promise<void> {
+  const p = path.join(
+    os.tmpdir(),
+    `webusd-conv-streaming-${process.pid}-${Math.random().toString(36).slice(2)}.usdz`
+  );
+  try {
+    await fn(p);
+  } finally {
+    try { fs.unlinkSync(p); } catch { /* best-effort */ }
+  }
+}
+
+
+describe('Converter streaming — byte-equivalence with buffered output', () => {
+
+  describe.skipIf(!hasButterfly)('GLB → USDZ', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-25T12:00:00Z'));
+    });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('streaming output is byte-identical to buffered output', async () => {
+      const buffer = fs.readFileSync(BUTTERFLY_GLB).buffer as ArrayBuffer;
+      const buffered = await blobToBytes(await convertGlbToUsdz(buffer));
+
+      await withTmp(async (tmpPath) => {
+        const result = await convertGlbToUsdz(buffer, undefined, { outputPath: tmpPath });
+        const onDisk = fs.readFileSync(tmpPath);
+
+        expect(result.totalBytes, 'totalBytes matches on-disk size').toBe(onDisk.length);
+        expect(onDisk.length, 'on-disk size matches buffered size').toBe(buffered.length);
+        expect(Buffer.compare(onDisk, Buffer.from(buffered)), 'byte content is identical').toBe(0);
+      });
+    });
+
+    it('result metadata is consistent', async () => {
+      const buffer = fs.readFileSync(BUTTERFLY_GLB).buffer as ArrayBuffer;
+
+      await withTmp(async (tmpPath) => {
+        const result = await convertGlbToUsdz(buffer, undefined, { outputPath: tmpPath });
+        const onDisk = fs.readFileSync(tmpPath);
+
+        expect(result.totalBytes).toBe(onDisk.length);
+        expect(result.fileCount).toBeGreaterThan(0);
+        // The output is a valid USDZ: starts with ZIP local-file-header magic.
+        expect(onDisk[0]).toBe(0x50);
+        expect(onDisk[1]).toBe(0x4b);
+        expect(onDisk[2]).toBe(0x03);
+        expect(onDisk[3]).toBe(0x04);
+      });
+    });
+  });
+
+  describe('PLY → USDZ', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-25T12:00:00Z'));
+    });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('streaming output is byte-identical to buffered output', async () => {
+      const buffer = makeMinimalPly();
+      const buffered = await blobToBytes(await convertPlyToUsdz(buffer));
+
+      await withTmp(async (tmpPath) => {
+        const result = await convertPlyToUsdz(buffer, undefined, { outputPath: tmpPath });
+        const onDisk = fs.readFileSync(tmpPath);
+
+        expect(result.totalBytes).toBe(onDisk.length);
+        expect(onDisk.length).toBe(buffered.length);
+        expect(Buffer.compare(onDisk, Buffer.from(buffered))).toBe(0);
+      });
+    });
+
+    it('result metadata is consistent', async () => {
+      await withTmp(async (tmpPath) => {
+        const result = await convertPlyToUsdz(makeMinimalPly(), undefined, { outputPath: tmpPath });
+        const onDisk = fs.readFileSync(tmpPath);
+
+        expect(result.totalBytes).toBe(onDisk.length);
+        expect(result.fileCount).toBeGreaterThan(0);
+        expect(onDisk[0]).toBe(0x50);
+        expect(onDisk[1]).toBe(0x4b);
+      });
+    });
+  });
+
+  describe('OBJ → USDZ', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-25T12:00:00Z'));
+    });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('streaming output is byte-identical to buffered output', async () => {
+      const buffer = makeMinimalObj();
+      const buffered = await blobToBytes(await convertObjToUsdz(buffer));
+
+      await withTmp(async (tmpPath) => {
+        const result = await convertObjToUsdz(buffer, undefined, { outputPath: tmpPath });
+        const onDisk = fs.readFileSync(tmpPath);
+
+        expect(result.totalBytes).toBe(onDisk.length);
+        expect(onDisk.length).toBe(buffered.length);
+        expect(Buffer.compare(onDisk, Buffer.from(buffered))).toBe(0);
+      });
+    });
+
+    it('result metadata is consistent', async () => {
+      await withTmp(async (tmpPath) => {
+        const result = await convertObjToUsdz(makeMinimalObj(), undefined, { outputPath: tmpPath });
+        const onDisk = fs.readFileSync(tmpPath);
+
+        expect(result.totalBytes).toBe(onDisk.length);
+        expect(result.fileCount).toBeGreaterThan(0);
+        expect(onDisk[0]).toBe(0x50);
+        expect(onDisk[1]).toBe(0x4b);
+      });
+    });
+  });
+
+  describe('STL → USDZ', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-25T12:00:00Z'));
+    });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('streaming output is byte-identical to buffered output', async () => {
+      const buffer = makeMinimalStl();
+      const buffered = await blobToBytes(await convertStlToUsdz(buffer));
+
+      await withTmp(async (tmpPath) => {
+        const result = await convertStlToUsdz(buffer, undefined, { outputPath: tmpPath });
+        const onDisk = fs.readFileSync(tmpPath);
+
+        expect(result.totalBytes).toBe(onDisk.length);
+        expect(onDisk.length).toBe(buffered.length);
+        expect(Buffer.compare(onDisk, Buffer.from(buffered))).toBe(0);
+      });
+    });
+
+    it('result metadata is consistent', async () => {
+      await withTmp(async (tmpPath) => {
+        const result = await convertStlToUsdz(makeMinimalStl(), undefined, { outputPath: tmpPath });
+        const onDisk = fs.readFileSync(tmpPath);
+
+        expect(result.totalBytes).toBe(onDisk.length);
+        expect(result.fileCount).toBeGreaterThan(0);
+        expect(onDisk[0]).toBe(0x50);
+        expect(onDisk[1]).toBe(0x4b);
+      });
+    });
+  });
+});

--- a/src/converters/gltf/gltf-converter.ts
+++ b/src/converters/gltf/gltf-converter.ts
@@ -13,7 +13,10 @@ import {
 } from './helpers/usd-hierarchy-builder';
 import {
   createUsdzPackage,
-  PackageContent
+  createUsdzPackageToFile,
+  PackageContent,
+  ConvertOptions,
+  UsdzStreamResult
 } from '../shared/usd-packaging';
 import { processAnimations, setAnimatedExtentOnSkelRoots, setAnimatedExtentOnAllSkelRoots } from './helpers/animation-processor';
 import {
@@ -82,10 +85,20 @@ const STRING_CONSTANTS = {
 /**
  * Convert GLB buffer or GLTF file to USDZ blob
  */
-export async function convertGlbToUsdz(
+export function convertGlbToUsdz(
   input: ArrayBuffer | string,
   config?: GltfTransformConfig
-): Promise<Blob> {
+): Promise<Blob>;
+export function convertGlbToUsdz(
+  input: ArrayBuffer | string,
+  config: GltfTransformConfig | undefined,
+  options: ConvertOptions & { outputPath: string }
+): Promise<UsdzStreamResult>;
+export async function convertGlbToUsdz(
+  input: ArrayBuffer | string,
+  config?: GltfTransformConfig,
+  options?: ConvertOptions
+): Promise<Blob | UsdzStreamResult> {
   const logger = LoggerFactory.forConversion();
 
   try {
@@ -1336,6 +1349,17 @@ export async function convertGlbToUsdz(
       stage: CONVERSION_STAGES.PACKAGING,
       fileCount: CONVERSION_CONSTANTS.MAIN_USD_FILE_COUNT + packageContent.geometryFiles.size + packageContent.textureFiles.size
     });
+
+    if (options?.outputPath) {
+      const result = await createUsdzPackageToFile(packageContent, options.outputPath);
+      logger.info('USDZ conversion completed', {
+        stage: CONVERSION_STAGES.COMPLETE,
+        usdzSize: result.totalBytes,
+        mode: 'streaming',
+        outputPath: options.outputPath
+      });
+      return result;
+    }
 
     const usdzBlob = await createUsdzPackage(packageContent);
 

--- a/src/converters/obj/obj-converter.ts
+++ b/src/converters/obj/obj-converter.ts
@@ -8,8 +8,11 @@ import { createRootStructure } from '../shared/usd-root-builder';
 import { adaptObjMeshesToUsd, createUsdMeshFromObj } from './helpers/obj-to-usd-adapter';
 import {
   createUsdzPackage,
+  createUsdzPackageToFile,
   PackageContent,
-  getTextureExtensionFromData
+  getTextureExtensionFromData,
+  ConvertOptions,
+  UsdzStreamResult
 } from '../shared/usd-packaging';
 import {
   writeDebugOutput,
@@ -113,10 +116,20 @@ function resolveTexturePath(mtlDir: string, rel: string, extraRoots: string[] = 
   return undefined;
 }
 
-export async function convertObjToUsdz(
+export function convertObjToUsdz(
   input: ArrayBuffer | string,
   config?: ObjConverterConfig
-): Promise<Blob> {
+): Promise<Blob>;
+export function convertObjToUsdz(
+  input: ArrayBuffer | string,
+  config: ObjConverterConfig | undefined,
+  options: ConvertOptions & { outputPath: string }
+): Promise<UsdzStreamResult>;
+export async function convertObjToUsdz(
+  input: ArrayBuffer | string,
+  config?: ObjConverterConfig,
+  options?: ConvertOptions
+): Promise<Blob | UsdzStreamResult> {
   const logger = LoggerFactory.forConversion();
 
   try {
@@ -269,6 +282,17 @@ export async function convertObjToUsdz(
       geometryFiles: new Map(), // No separate geometry files - embedded in main USD
       textureFiles
     };
+
+    if (options?.outputPath) {
+      const result = await createUsdzPackageToFile(packageContent, options.outputPath);
+      logger.info('USDZ conversion completed', {
+        stage: 'conversion_complete',
+        usdzSize: result.totalBytes,
+        mode: 'streaming',
+        outputPath: options.outputPath
+      });
+      return result;
+    }
 
     const usdzBlob = await createUsdzPackage(packageContent);
 

--- a/src/converters/ply/ply-converter.ts
+++ b/src/converters/ply/ply-converter.ts
@@ -7,7 +7,10 @@ import { decimateMesh } from './mesh-decimator';
 import { createRootStructure } from '../shared/usd-root-builder';
 import {
   createUsdzPackage,
-  PackageContent
+  createUsdzPackageToFile,
+  PackageContent,
+  ConvertOptions,
+  UsdzStreamResult
 } from '../shared/usd-packaging';
 import {
   writeDebugOutput,
@@ -223,10 +226,20 @@ function createBasicMaterial(
 /**
  * Main PLY to USDZ conversion function.
  */
-export async function convertPlyToUsdz(
+export function convertPlyToUsdz(
   input: ArrayBuffer | string,
   config?: Partial<PlyConverterConfig>
-): Promise<Blob> {
+): Promise<Blob>;
+export function convertPlyToUsdz(
+  input: ArrayBuffer | string,
+  config: Partial<PlyConverterConfig> | undefined,
+  options: ConvertOptions & { outputPath: string }
+): Promise<UsdzStreamResult>;
+export async function convertPlyToUsdz(
+  input: ArrayBuffer | string,
+  config?: Partial<PlyConverterConfig>,
+  options?: ConvertOptions
+): Promise<Blob | UsdzStreamResult> {
   const logger = LoggerFactory.forConversion();
 
   try {
@@ -366,6 +379,17 @@ export async function convertPlyToUsdz(
       geometryFiles: new Map(),
       textureFiles: new Map(),
     };
+
+    if (options?.outputPath) {
+      const result = await createUsdzPackageToFile(packageContent, options.outputPath);
+      logger.info('USDZ conversion completed', {
+        stage: 'conversion_complete',
+        usdzSize: result.totalBytes,
+        mode: 'streaming',
+        outputPath: options.outputPath,
+      });
+      return result;
+    }
 
     const usdzBlob = await createUsdzPackage(packageContent);
 

--- a/src/converters/shared/usd-packaging.ts
+++ b/src/converters/shared/usd-packaging.ts
@@ -132,6 +132,30 @@ export interface UsdzStreamOptions {
 }
 
 /**
+ * Options for opting a per-format converter (`convertGlbToUsdz`,
+ * `convertPlyToUsdz`, `convertObjToUsdz`, `convertStlToUsdz`) and
+ * `WebUsdFramework.convert` into the streaming output path.
+ */
+export interface ConvertOptions {
+  /**
+   * When set, stream the USDZ archive directly to this file path via
+   * `createUsdzPackageToFile`. The converter returns `UsdzStreamResult`
+   * (`{ totalBytes, fileCount }`) instead of a `Blob`.
+   *
+   * Memory peak is bounded by the largest single file inside the archive
+   * (the buffered path peaks at the full archive size). For dense point-
+   * cloud archives this is an order-of-magnitude reduction.
+   *
+   * NOTE: when this option is used together with `debug: true`, the
+   * debug-blob portion of the debug output (the full `.usdz` written
+   * alongside the unpacked artifacts) is skipped. The other debug
+   * artifacts (USDA, geometry, textures) still emit. To get the full
+   * debug bundle including the archive blob, omit `outputPath`.
+   */
+  outputPath?: string;
+}
+
+/**
  * Stream a USDZ package to any Node `Writable`.
  *
  * Memory peak is bounded by the largest single file in the archive, not the

--- a/src/converters/stl/stl-converter.ts
+++ b/src/converters/stl/stl-converter.ts
@@ -6,7 +6,10 @@ import { parseStl, parseStlFile, StlMeshData } from './stl-parser';
 import { createRootStructure } from '../shared/usd-root-builder';
 import {
   createUsdzPackage,
-  PackageContent
+  createUsdzPackageToFile,
+  PackageContent,
+  ConvertOptions,
+  UsdzStreamResult
 } from '../shared/usd-packaging';
 import {
   writeDebugOutput,
@@ -231,10 +234,20 @@ function createBasicMaterial(
 /**
  * Main STL to USDZ conversion function
  */
-export async function convertStlToUsdz(
+export function convertStlToUsdz(
   input: ArrayBuffer | string,
   config?: Partial<StlConverterConfig>
-): Promise<Blob> {
+): Promise<Blob>;
+export function convertStlToUsdz(
+  input: ArrayBuffer | string,
+  config: Partial<StlConverterConfig> | undefined,
+  options: ConvertOptions & { outputPath: string }
+): Promise<UsdzStreamResult>;
+export async function convertStlToUsdz(
+  input: ArrayBuffer | string,
+  config?: Partial<StlConverterConfig>,
+  options?: ConvertOptions
+): Promise<Blob | UsdzStreamResult> {
   const logger = LoggerFactory.forConversion();
 
   try {
@@ -613,6 +626,17 @@ export async function convertStlToUsdz(
       geometryFiles: new Map(), // Embedded geometry
       textureFiles: new Map() // No textures for STL
     };
+
+    if (options?.outputPath) {
+      const result = await createUsdzPackageToFile(packageContent, options.outputPath);
+      logger.info('USDZ conversion completed', {
+        stage: 'conversion_complete',
+        usdzSize: result.totalBytes,
+        mode: 'streaming',
+        outputPath: options.outputPath
+      });
+      return result;
+    }
 
     const usdzBlob = await createUsdzPackage(packageContent);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { convertObjToUsdz } from './converters/obj';
 import { convertFbxToGltfViaTool } from './converters/fbx';
 import { convertStlToUsdz } from './converters/stl';
 import { convertPlyToUsdz } from './converters/ply';
+import type { UsdzStreamResult } from './converters/shared/usd-packaging';
 import { UsdErrorFactory } from './errors';
 import { WebUsdConfigSchema, type WebUsdConfig } from './schemas';
 import { ZodError } from 'zod';
@@ -50,7 +51,56 @@ export class WebUsdFramework {
    * const usdzBlob = await usd.convert(buffer);
    * ```
    */
-  async convert(input: string | ArrayBuffer, options?: { mtlPath?: string; mtlSearchPaths?: string[]; textureSearchPaths?: string[]; allowAutoTextureFallback?: boolean }): Promise<Blob> {
+  /**
+   * Convert a 3D model to USDZ.
+   *
+   * Returns a `Blob` by default. If `options.outputPath` is provided the
+   * archive is streamed to that file path and the function returns a
+   * `UsdzStreamResult` (`{ totalBytes, fileCount }`) — memory peak in that
+   * mode is bounded by the largest single file in the archive instead of
+   * the total archive size.
+   */
+  async convert(
+    input: string | ArrayBuffer,
+    options?: {
+      mtlPath?: string;
+      mtlSearchPaths?: string[];
+      textureSearchPaths?: string[];
+      allowAutoTextureFallback?: boolean;
+    }
+  ): Promise<Blob>;
+  async convert(
+    input: string | ArrayBuffer,
+    options: {
+      mtlPath?: string;
+      mtlSearchPaths?: string[];
+      textureSearchPaths?: string[];
+      allowAutoTextureFallback?: boolean;
+      /**
+       * Stream the USDZ archive directly to this file path instead of
+       * returning a Blob. Memory peak is bounded by the largest single
+       * file in the archive — order-of-magnitude reduction for large
+       * point-cloud and multi-mesh inputs.
+       */
+      outputPath: string;
+    }
+  ): Promise<UsdzStreamResult>;
+  async convert(
+    input: string | ArrayBuffer,
+    options?: {
+      mtlPath?: string;
+      mtlSearchPaths?: string[];
+      textureSearchPaths?: string[];
+      allowAutoTextureFallback?: boolean;
+      outputPath?: string;
+    }
+  ): Promise<Blob | UsdzStreamResult> {
+    // Resolve streaming options once so each per-format dispatch can forward
+    // them uniformly. Treated as `undefined` when no outputPath was given so
+    // existing buffered behaviour (returning a Blob) is preserved bit-for-bit.
+    const streamOpts: { outputPath: string } | undefined = options?.outputPath
+      ? { outputPath: options.outputPath }
+      : undefined;
     if (this.config.debug) {
       console.log('Debug mode enabled');
       console.log(`Debug output: ${this.config.debugOutputDir}`);
@@ -84,7 +134,9 @@ export class WebUsdFramework {
 
       // Handle different file types
       if (fileExtension === '.gltf') {
-        return await convertGlbToUsdz(filePath, this.config);
+        return streamOpts
+          ? await convertGlbToUsdz(filePath, this.config, streamOpts)
+          : await convertGlbToUsdz(filePath, this.config);
       } else if (fileExtension === '.obj' || fileExtension === '.OBJ') {
         // Convert WebUsdConfig to ObjConverterConfig
         const objConfig = {
@@ -101,7 +153,9 @@ export class WebUsdFramework {
           useIndices: true,
           disregardNormals: false
         };
-        return await convertObjToUsdz(filePath, objConfig);
+        return streamOpts
+          ? await convertObjToUsdz(filePath, objConfig, streamOpts)
+          : await convertObjToUsdz(filePath, objConfig);
       } else if (fileExtension === '.glb') {
         // For GLB files, read as buffer
         const fileBuffer = fs.readFileSync(filePath);
@@ -109,7 +163,9 @@ export class WebUsdFramework {
           fileBuffer.byteOffset,
           fileBuffer.byteOffset + fileBuffer.byteLength
         );
-        return await convertGlbToUsdz(glbBuffer, this.config);
+        return streamOpts
+          ? await convertGlbToUsdz(glbBuffer, this.config, streamOpts)
+          : await convertGlbToUsdz(glbBuffer, this.config);
       } else if (fileExtension === '.fbx') {
         // Use FBX2glTF tool to convert FBX to GLB first
         const glbBuffer = await convertFbxToGltfViaTool(filePath, {
@@ -118,7 +174,9 @@ export class WebUsdFramework {
         });
 
         // Then convert GLB to USDZ
-        return await convertGlbToUsdz(glbBuffer, this.config);
+        return streamOpts
+          ? await convertGlbToUsdz(glbBuffer, this.config, streamOpts)
+          : await convertGlbToUsdz(glbBuffer, this.config);
       } else if (fileExtension === '.stl') {
         // Convert STL to USDZ
         const stlConfig = {
@@ -130,7 +188,9 @@ export class WebUsdFramework {
           defaultColor: [0.7, 0.7, 0.7] as [number, number, number],
           autoComputeNormals: true
         };
-        return await convertStlToUsdz(filePath, stlConfig);
+        return streamOpts
+          ? await convertStlToUsdz(filePath, stlConfig, streamOpts)
+          : await convertStlToUsdz(filePath, stlConfig);
       } else if (fileExtension === '.ply') {
         // Convert PLY to USDZ
         const plyConfig = {
@@ -143,7 +203,9 @@ export class WebUsdFramework {
           maxPoints: 0,
           decimateTarget: 0,
         };
-        return await convertPlyToUsdz(filePath, plyConfig);
+        return streamOpts
+          ? await convertPlyToUsdz(filePath, plyConfig, streamOpts)
+          : await convertPlyToUsdz(filePath, plyConfig);
       } else {
         throw UsdErrorFactory.conversionError(
           `Unsupported file format: ${fileExtension}`,
@@ -153,7 +215,9 @@ export class WebUsdFramework {
     }
 
     // Handle ArrayBuffer input (GLB only)
-    return await convertGlbToUsdz(input, this.config);
+    return streamOpts
+      ? await convertGlbToUsdz(input, this.config, streamOpts)
+      : await convertGlbToUsdz(input, this.config);
   }
 
   // Extract ZIP file and find FBX inside
@@ -240,3 +304,19 @@ export { convertGlbToUsdz } from './converters/gltf';
 export { convertObjToUsdz } from './converters/obj';
 export { convertStlToUsdz } from './converters/stl';
 export { convertPlyToUsdz } from './converters/ply';
+
+/**
+ * Streaming USDZ packaging — for callers that already hold a `PackageContent`
+ * and want to stream the resulting archive to disk or a Writable instead of
+ * materializing a Blob.
+ */
+export {
+  createUsdzPackage,
+  createUsdzPackageToStream,
+  createUsdzPackageToFile,
+  type ConvertOptions,
+  type UsdzStreamOptions,
+  type UsdzStreamResult,
+  type PackageContent,
+  type PackageConfig,
+} from './converters/shared/usd-packaging';


### PR DESCRIPTION
## Summary

- Wire the streaming output path (`outputPath` option → disk file) through all four format converters (GLB, PLY, OBJ, STL), `WebUsdFramework.convert()`, and the CLI `convert.cjs` script
- Add TypeScript overloads to all four `convertXxxToUsdz` functions: callers without `outputPath` receive `Promise<Blob>`; callers with `outputPath` receive `Promise<UsdzStreamResult>`
- Add `ConvertOptions` interface and matching overloads to `WebUsdFramework.convert()` in `src/index.ts`
- Expose `UsdzStreamResult`, `ConvertOptions`, `UsdzStreamOptions`, and the streaming packaging functions from the public API surface
- Update `scripts/convert.cjs` to use the `outputPath` option directly, removing the old `Readable`/`pipeline` indirection
- Add `src/__tests__/converter-streaming.test.ts`: per-converter byte-equivalence tests for all four formats, with pinned fake timers for deterministic ZIP timestamps; GLB tests guarded by fixture availability

## Test plan

- [ ] All 70 tests pass (`pnpm run test:run`)
- [ ] Type-check clean (`pnpm run type-check`)
- [ ] New `converter-streaming` tests cover GLB (butterfly fixture), PLY, OBJ, STL — streaming bytes are byte-identical to buffered Blob output for each format
- [ ] CLI smoke test: `node scripts/convert.cjs <input.glb>` writes `<output>.usdz` and prints `totalBytes` + `fileCount`

Closes #120