### PR TITLE
feat(usdc): UsdNode adapter + layerFormat='usdc' pipeline integration

### DIFF
--- a/src/__tests__/usdc-package-integration.test.ts
+++ b/src/__tests__/usdc-package-integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * End-to-end tests for the layerFormat: 'usdc' option through the packaging
+ * pipeline.
+ *
+ * The packager honors `config.layerFormat`:
+ *   - 'usda' (default)  → emits the root layer as text (`model.usda`).
+ *   - 'usdc'            → tries to emit the root layer as binary
+ *                          (`model.usdc`) using the UsdNode → USDC adapter.
+ *                          Falls back to USDA when the source tree was not
+ *                          provided OR contains properties the adapter can't
+ *                          encode yet.
+ *
+ * These tests cover both branches plus the fallback safety net.
+ */
+import { describe, it, expect } from 'vitest';
+import { UsdNode } from '../core/usd-node';
+import {
+  createUsdzPackage,
+  type PackageContent,
+} from '../converters/shared/usd-packaging';
+
+/** Read every file inside a USDZ blob and return their names. */
+async function readArchiveNames(blob: Blob): Promise<string[]> {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  const names: string[] = [];
+  let cursor = 0;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  while (cursor + 4 <= bytes.length) {
+    const sig = view.getUint32(cursor, true);
+    if (sig !== 0x04034b50) break; // PK\3\4 — local file header
+    const nameLen = view.getUint16(cursor + 26, true);
+    const extraLen = view.getUint16(cursor + 28, true);
+    const compressedSize = view.getUint32(cursor + 18, true);
+    const name = new TextDecoder().decode(
+      bytes.subarray(cursor + 30, cursor + 30 + nameLen)
+    );
+    names.push(name);
+    cursor += 30 + nameLen + extraLen + compressedSize;
+  }
+  return names;
+}
+
+function basicContent(): PackageContent {
+  return {
+    usdContent: '#usda 1.0\n(\n  defaultPrim = "Root"\n)\n\ndef Xform "Root" {}\n',
+    geometryFiles: new Map(),
+    textureFiles: new Map(),
+  };
+}
+
+function basicTree(): UsdNode {
+  // A tree the adapter can fully encode.
+  const root = new UsdNode('/Root', 'Xform');
+  const mesh = new UsdNode('/Root/Mesh', 'Mesh');
+  mesh.setProperty('point3f[] points', new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]));
+  mesh.setProperty('int[] faceVertexIndices', new Int32Array([0, 1, 2]));
+  mesh.setProperty('int[] faceVertexCounts', new Int32Array([3]));
+  root.addChild(mesh);
+  return root;
+}
+
+describe('layerFormat — default ("usda")', () => {
+  it('writes model.usda when layerFormat is omitted', async () => {
+    const blob = await createUsdzPackage(basicContent());
+    const names = await readArchiveNames(blob);
+    expect(names).toContain('model.usda');
+    expect(names).not.toContain('model.usdc');
+  });
+
+  it('writes model.usda when layerFormat is explicitly "usda"', async () => {
+    const blob = await createUsdzPackage(basicContent(), { layerFormat: 'usda' });
+    const names = await readArchiveNames(blob);
+    expect(names).toContain('model.usda');
+  });
+});
+
+describe('layerFormat — "usdc"', () => {
+  it('writes model.usdc when usdContentNode is provided and adapter succeeds', async () => {
+    const content: PackageContent = {
+      ...basicContent(),
+      usdContentNode: basicTree(),
+    };
+    const blob = await createUsdzPackage(content, { layerFormat: 'usdc' });
+    const names = await readArchiveNames(blob);
+    expect(names).toContain('model.usdc');
+    expect(names).not.toContain('model.usda');
+  });
+
+  it('falls back to model.usda when usdContentNode is missing', async () => {
+    const blob = await createUsdzPackage(basicContent(), { layerFormat: 'usdc' });
+    const names = await readArchiveNames(blob);
+    expect(names).toContain('model.usda');
+    expect(names).not.toContain('model.usdc');
+  });
+
+  it('falls back to model.usda when the tree contains unsupported properties', async () => {
+    const root = new UsdNode('/Root', 'Xform');
+    // material:binding is a relationship — adapter does not yet emit these.
+    root.setProperty('material:binding', '<x>');
+
+    const content: PackageContent = {
+      ...basicContent(),
+      usdContentNode: root,
+    };
+    const blob = await createUsdzPackage(content, { layerFormat: 'usdc' });
+    const names = await readArchiveNames(blob);
+    expect(names).toContain('model.usda');
+    expect(names).not.toContain('model.usdc');
+  });
+
+  it('USDC root layer starts with PXR-USDC magic when emitted', async () => {
+    const content: PackageContent = {
+      ...basicContent(),
+      usdContentNode: basicTree(),
+    };
+    const blob = await createUsdzPackage(content, { layerFormat: 'usdc' });
+    const archive = new Uint8Array(await blob.arrayBuffer());
+
+    // Find model.usdc inside the archive and verify its first 8 bytes.
+    const view = new DataView(archive.buffer, archive.byteOffset, archive.byteLength);
+    let cursor = 0;
+    let found = false;
+    while (cursor + 4 <= archive.length) {
+      const sig = view.getUint32(cursor, true);
+      if (sig !== 0x04034b50) break;
+      const nameLen = view.getUint16(cursor + 26, true);
+      const extraLen = view.getUint16(cursor + 28, true);
+      const compressedSize = view.getUint32(cursor + 18, true);
+      const name = new TextDecoder().decode(
+        archive.subarray(cursor + 30, cursor + 30 + nameLen)
+      );
+      if (name === 'model.usdc') {
+        const dataStart = cursor + 30 + nameLen + extraLen;
+        // PXR-USDC magic.
+        const magic = String.fromCharCode(
+          archive[dataStart], archive[dataStart + 1], archive[dataStart + 2], archive[dataStart + 3],
+          archive[dataStart + 4], archive[dataStart + 5], archive[dataStart + 6], archive[dataStart + 7]
+        );
+        expect(magic).toBe('PXR-USDC');
+        found = true;
+        break;
+      }
+      cursor += 30 + nameLen + extraLen + compressedSize;
+    }
+    expect(found).toBe(true);
+  });
+});

--- a/src/__tests__/usdc-property-parser.test.ts
+++ b/src/__tests__/usdc-property-parser.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for the UsdNode property-key parser.
+ *
+ * UsdNode property keys use a USDA-style line head; the parser splits them
+ * into a structured descriptor the USDC encoder can switch on. These tests
+ * cover the typical scalar / array / qualified-attribute shapes the live
+ * converters emit, plus the common non-attribute keys (relationships,
+ * connections, list-ops) that are routed back to the USDA fallback.
+ */
+import { describe, it, expect } from 'vitest';
+import { parsePropertyKey } from '../converters/shared/usdc/property-parser';
+import { CrateDataType } from '../converters/shared/usdc/value-rep';
+
+describe('parsePropertyKey — scalar attributes', () => {
+  it('parses a float scalar', () => {
+    const r = parsePropertyKey('float inputs:roughness');
+    expect(r).toEqual({
+      kind: 'attribute',
+      name: 'inputs:roughness',
+      type: CrateDataType.Float,
+      isArray: false,
+      isUniform: false,
+    });
+  });
+
+  it('parses a token scalar', () => {
+    const r = parsePropertyKey('token outputs:surface');
+    expect(r).toEqual({
+      kind: 'attribute',
+      name: 'outputs:surface',
+      type: CrateDataType.Token,
+      isArray: false,
+      isUniform: false,
+    });
+  });
+
+  it('parses a uniform-qualified token', () => {
+    const r = parsePropertyKey('uniform token info:id');
+    expect(r).toEqual({
+      kind: 'attribute',
+      name: 'info:id',
+      type: CrateDataType.Token,
+      isArray: false,
+      isUniform: true,
+    });
+  });
+
+  it('parses a uniform-qualified primvar token', () => {
+    const r = parsePropertyKey('uniform token primvars:displayColor:interpolation');
+    if (r.kind !== 'attribute') throw new Error('expected attribute');
+    expect(r.name).toBe('primvars:displayColor:interpolation');
+    expect(r.type).toBe(CrateDataType.Token);
+    expect(r.isUniform).toBe(true);
+  });
+
+  it('parses an int scalar', () => {
+    const r = parsePropertyKey('int someCount');
+    expect(r.kind).toBe('attribute');
+    if (r.kind !== 'attribute') return;
+    expect(r.type).toBe(CrateDataType.Int);
+  });
+
+  it('parses a color3f scalar (Vec3f)', () => {
+    const r = parsePropertyKey('color3f inputs:diffuseColor');
+    if (r.kind !== 'attribute') throw new Error('expected attribute');
+    expect(r.type).toBe(CrateDataType.Vec3f);
+    expect(r.isArray).toBe(false);
+  });
+});
+
+describe('parsePropertyKey — array attributes', () => {
+  it('parses point3f[] points', () => {
+    const r = parsePropertyKey('point3f[] points');
+    expect(r).toEqual({
+      kind: 'attribute',
+      name: 'points',
+      type: CrateDataType.Vec3f,
+      isArray: true,
+      isUniform: false,
+    });
+  });
+
+  it('parses normal3f[] normals', () => {
+    const r = parsePropertyKey('normal3f[] normals');
+    if (r.kind !== 'attribute') throw new Error('expected attribute');
+    expect(r.type).toBe(CrateDataType.Vec3f);
+    expect(r.isArray).toBe(true);
+  });
+
+  it('parses color3f[] primvars:displayColor', () => {
+    const r = parsePropertyKey('color3f[] primvars:displayColor');
+    if (r.kind !== 'attribute') throw new Error('expected attribute');
+    expect(r.name).toBe('primvars:displayColor');
+    expect(r.type).toBe(CrateDataType.Vec3f);
+    expect(r.isArray).toBe(true);
+  });
+
+  it('parses float[] widths', () => {
+    const r = parsePropertyKey('float[] widths');
+    if (r.kind !== 'attribute') throw new Error('expected attribute');
+    expect(r.type).toBe(CrateDataType.Float);
+    expect(r.isArray).toBe(true);
+  });
+
+  it('parses int[] faceVertexIndices', () => {
+    const r = parsePropertyKey('int[] faceVertexIndices');
+    if (r.kind !== 'attribute') throw new Error('expected attribute');
+    expect(r.type).toBe(CrateDataType.Int);
+    expect(r.isArray).toBe(true);
+  });
+
+  it('parses float3[] extent (treated as Vec3f[])', () => {
+    const r = parsePropertyKey('float3[] extent');
+    if (r.kind !== 'attribute') throw new Error('expected attribute');
+    expect(r.type).toBe(CrateDataType.Vec3f);
+    expect(r.isArray).toBe(true);
+  });
+
+  it('parses texCoord2f[] (Vec2f[])', () => {
+    const r = parsePropertyKey('texCoord2f[] primvars:st');
+    if (r.kind !== 'attribute') throw new Error('expected attribute');
+    expect(r.type).toBe(CrateDataType.Vec2f);
+    expect(r.isArray).toBe(true);
+  });
+});
+
+describe('parsePropertyKey — non-attribute keys (unsupported)', () => {
+  it('returns unsupported for prepend metadata', () => {
+    const r = parsePropertyKey('prepend apiSchemas');
+    expect(r.kind).toBe('unsupported');
+  });
+
+  it('returns unsupported for prepend references', () => {
+    const r = parsePropertyKey('prepend references');
+    expect(r.kind).toBe('unsupported');
+  });
+
+  it('returns unsupported for connection (.connect suffix)', () => {
+    const r = parsePropertyKey('token outputs:surface.connect');
+    expect(r.kind).toBe('unsupported');
+  });
+
+  it('returns unsupported for material:binding', () => {
+    const r = parsePropertyKey('material:binding');
+    expect(r.kind).toBe('unsupported');
+  });
+
+  it('returns unsupported for an unknown type token', () => {
+    const r = parsePropertyKey('matrix4d someXform');
+    expect(r.kind).toBe('unsupported');
+    if (r.kind === 'unsupported') {
+      expect(r.reason).toContain('matrix4d');
+    }
+  });
+});
+
+describe('parsePropertyKey — malformed input', () => {
+  it('returns unsupported for an empty string', () => {
+    expect(parsePropertyKey('').kind).toBe('unsupported');
+  });
+
+  it('returns unsupported for whitespace only', () => {
+    expect(parsePropertyKey('   ').kind).toBe('unsupported');
+  });
+
+  it('returns unsupported for a type token without a name', () => {
+    expect(parsePropertyKey('float').kind).toBe('unsupported');
+  });
+});

--- a/src/__tests__/usdc-usd-node-adapter.test.ts
+++ b/src/__tests__/usdc-usd-node-adapter.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for the UsdNode → UsdcLayerBuilder adapter.
+ *
+ * The adapter is the "live wire" between the converters' existing scene
+ * graph and the binary encoder. These tests verify:
+ *   - that representative scene fragments produce structurally-valid USDC,
+ *   - that the per-property type dispatch covers the shapes the live PLY /
+ *     OBJ / STL / GLB converters emit,
+ *   - that unsupported keys (relationships, list-ops, connections) are
+ *     reported but do not abort the walk,
+ *   - that the resulting USDC contains the tokens, paths, fields, and specs
+ *     we'd expect for the input.
+ */
+import { describe, it, expect } from 'vitest';
+import { UsdNode } from '../core/usd-node';
+import {
+  adaptUsdNodeTree,
+  applyProperty,
+  encodeUsdNodeTreeToUsdc,
+} from '../converters/shared/usdc/usd-node-adapter';
+import { UsdcLayerBuilder } from '../converters/shared/usdc/layer-builder';
+import { decodeTokensSection } from '../converters/shared/usdc/tokens-section';
+import { decodeSpecsSection } from '../converters/shared/usdc/specs-section';
+import { decodeFieldsSection } from '../converters/shared/usdc/fields-section';
+import {
+  USDC_BOOTSTRAP_SIZE,
+  USDC_MAGIC,
+  USDC_SECTION_NAME_SIZE,
+} from '../converters/shared/usdc-writer';
+import {
+  decodeValueRep,
+  CrateDataType,
+  SdfSpecType,
+} from '../converters/shared/usdc/value-rep';
+
+interface TocEntry { name: string; start: number; size: number }
+
+function readToc(bytes: Uint8Array): TocEntry[] {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const tocOffset = Number(view.getBigInt64(16, true));
+  const numSections = Number(view.getBigUint64(tocOffset, true));
+  const entries: TocEntry[] = new Array(numSections);
+  let cursor = tocOffset + 8;
+  for (let i = 0; i < numSections; i++) {
+    let nameEnd = USDC_SECTION_NAME_SIZE;
+    for (let j = 0; j < USDC_SECTION_NAME_SIZE; j++) {
+      if (bytes[cursor + j] === 0) {
+        nameEnd = j;
+        break;
+      }
+    }
+    const name = new TextDecoder().decode(bytes.subarray(cursor, cursor + nameEnd));
+    const start = Number(view.getBigInt64(cursor + USDC_SECTION_NAME_SIZE, true));
+    const size = Number(view.getBigInt64(cursor + USDC_SECTION_NAME_SIZE + 8, true));
+    entries[i] = { name, start, size };
+    cursor += USDC_SECTION_NAME_SIZE + 16;
+  }
+  return entries;
+}
+
+function getTokens(bytes: Uint8Array): string[] {
+  const e = readToc(bytes).find((s) => s.name === 'TOKENS')!;
+  return decodeTokensSection(bytes.subarray(e.start, e.start + e.size));
+}
+
+describe('applyProperty — scalar dispatch', () => {
+  it('emits a Float scalar for "float inputs:roughness"', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Xform');
+    const r = applyProperty(b, root, 'float inputs:roughness', 0.6);
+    expect(r.emitted).toBe(true);
+  });
+
+  it('parses numeric strings for float scalars', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Xform');
+    expect(applyProperty(b, root, 'float inputs:roughness', '0.6').emitted).toBe(true);
+  });
+
+  it('emits a Token scalar for "uniform token info:id"', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Material');
+    expect(
+      applyProperty(b, root, 'uniform token info:id', 'UsdPreviewSurface').emitted
+    ).toBe(true);
+  });
+
+  it('emits an empty Token for an empty string value', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Material');
+    expect(applyProperty(b, root, 'token outputs:surface', '').emitted).toBe(true);
+  });
+
+  it('skips unsupported scalar Vec3f literals (would need USDA-string parsing)', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Material');
+    const r = applyProperty(b, root, 'color3f inputs:diffuseColor', '(0.7, 0.7, 0.7)');
+    expect(r.emitted).toBe(false);
+    expect(r.reason).toBeDefined();
+  });
+
+  it('skips connection / relationship / list-op keys', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Material');
+    expect(applyProperty(b, root, 'token outputs:surface.connect', '<x>').emitted).toBe(false);
+    expect(applyProperty(b, root, 'material:binding', '<x>').emitted).toBe(false);
+    expect(applyProperty(b, root, 'prepend apiSchemas', ['x']).emitted).toBe(false);
+  });
+});
+
+describe('applyProperty — array dispatch', () => {
+  it('emits a Vec3f[] for "point3f[] points" with a Float32Array', () => {
+    const b = new UsdcLayerBuilder();
+    b.declarePrim('/Root', 'Xform');
+    const root = b.declarePrim('/Root/Mesh', 'Mesh');
+    const r = applyProperty(b, root, 'point3f[] points', new Float32Array([0, 0, 0, 1, 0, 0]));
+    expect(r.emitted).toBe(true);
+  });
+
+  it('rejects Vec3f[] when length is not a multiple of 3', () => {
+    const b = new UsdcLayerBuilder();
+    b.declarePrim('/Root', 'Xform');
+    const root = b.declarePrim('/Root/Mesh', 'Mesh');
+    const r = applyProperty(b, root, 'point3f[] points', new Float32Array([0, 0]));
+    expect(r.emitted).toBe(false);
+  });
+
+  it('emits a Float[] for "float[] widths" with a Float32Array', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Points');
+    const r = applyProperty(b, root, 'float[] widths', new Float32Array([0.1, 0.2, 0.3]));
+    expect(r.emitted).toBe(true);
+  });
+
+  it('emits an Int[] for "int[] faceVertexIndices"', () => {
+    const b = new UsdcLayerBuilder();
+    b.declarePrim('/Root', 'Xform');
+    const root = b.declarePrim('/Root/Mesh', 'Mesh');
+    const r = applyProperty(b, root, 'int[] faceVertexIndices', new Int32Array([0, 1, 2]));
+    expect(r.emitted).toBe(true);
+  });
+
+  it('coerces a plain number[] into the right typed array', () => {
+    const b = new UsdcLayerBuilder();
+    b.declarePrim('/Root', 'Xform');
+    const root = b.declarePrim('/Root/Mesh', 'Mesh');
+    expect(applyProperty(b, root, 'float[] widths', [0.1, 0.2, 0.3]).emitted).toBe(true);
+    expect(applyProperty(b, root, 'int[] faceVertexCounts', [3, 3, 3]).emitted).toBe(true);
+  });
+
+  it('emits a Token[] for a string array', () => {
+    const b = new UsdcLayerBuilder();
+    b.declarePrim('/Root', 'Xform');
+    const root = b.declarePrim('/Root/Mesh', 'Mesh');
+    const r = applyProperty(b, root, 'uniform token[] xformOpOrder', ['xformOp:translate']);
+    expect(r.emitted).toBe(true);
+  });
+
+  it('skips array attributes whose value is not the expected shape', () => {
+    const b = new UsdcLayerBuilder();
+    b.declarePrim('/Root', 'Xform');
+    const root = b.declarePrim('/Root/Mesh', 'Mesh');
+    expect(applyProperty(b, root, 'point3f[] points', 'not an array').emitted).toBe(false);
+    expect(applyProperty(b, root, 'int[] faceVertexIndices', [1.5, 2]).emitted).toBe(false);
+  });
+});
+
+describe('adaptUsdNodeTree — small scene', () => {
+  function makeScene(): UsdNode {
+    const root = new UsdNode('/Root', 'Xform');
+    const scene = new UsdNode('/Root/Scene', 'Scope');
+    const mesh = new UsdNode('/Root/Scene/PlyMesh', 'Mesh');
+    mesh.setProperty('point3f[] points', new Float32Array([
+      0, 0, 0,
+      1, 0, 0,
+      0, 1, 0,
+    ]));
+    mesh.setProperty('int[] faceVertexIndices', new Int32Array([0, 1, 2]));
+    mesh.setProperty('int[] faceVertexCounts', new Int32Array([3]));
+    scene.addChild(mesh);
+    root.addChild(scene);
+    return root;
+  }
+
+  it('walks every node in the tree', () => {
+    const root = makeScene();
+    const builder = new UsdcLayerBuilder();
+    const report = adaptUsdNodeTree(root, builder);
+    expect(report.primCount).toBe(3); // Root + Scene + PlyMesh
+    expect(report.skipped).toBe(0);
+  });
+
+  it('emitted USDC starts with PXR-USDC magic and has 6 sections', () => {
+    const { bytes, report } = encodeUsdNodeTreeToUsdc(makeScene());
+    for (let i = 0; i < USDC_MAGIC.length; i++) expect(bytes[i]).toBe(USDC_MAGIC[i]);
+    const toc = readToc(bytes);
+    expect(toc.map((s) => s.name)).toEqual([
+      'TOKENS',
+      'STRINGS',
+      'FIELDS',
+      'FIELDSETS',
+      'PATHS',
+      'SPECS',
+    ]);
+    expect(report.skipped).toBe(0);
+  });
+
+  it('TOKENS contains every prim name and property name from the source tree', () => {
+    const { bytes } = encodeUsdNodeTreeToUsdc(makeScene());
+    const tokens = getTokens(bytes);
+    for (const expected of [
+      'Root',
+      'Scene',
+      'PlyMesh',
+      'Xform',
+      'Scope',
+      'Mesh',
+      'points',
+      'faceVertexIndices',
+      'faceVertexCounts',
+    ]) {
+      expect(tokens).toContain(expected);
+    }
+  });
+
+  it('SPECS contains a row for each prim plus the pseudo-root', () => {
+    const { bytes } = encodeUsdNodeTreeToUsdc(makeScene());
+    const toc = readToc(bytes);
+    const specsEntry = toc.find((e) => e.name === 'SPECS')!;
+    const specs = decodeSpecsSection(bytes.subarray(specsEntry.start, specsEntry.start + specsEntry.size));
+    expect(specs.length).toBe(4); // PseudoRoot + Root + Scene + PlyMesh
+    expect(specs[0].specType).toBe(SdfSpecType.PseudoRoot);
+    for (let i = 1; i < specs.length; i++) {
+      expect(specs[i].specType).toBe(SdfSpecType.Prim);
+    }
+  });
+
+  it('FIELDS contains array ValueReps that point inside the file', () => {
+    const { bytes } = encodeUsdNodeTreeToUsdc(makeScene());
+    const toc = readToc(bytes);
+    const fieldsEntry = toc.find((e) => e.name === 'FIELDS')!;
+    const fields = decodeFieldsSection(bytes.subarray(fieldsEntry.start, fieldsEntry.start + fieldsEntry.size));
+    const arrayFields = fields.filter((f) => {
+      const v = decodeValueRep(f.valueRep);
+      return v.isArray && !v.isInlined;
+    });
+    // We added points + faceVertexIndices + faceVertexCounts → 3 array fields.
+    expect(arrayFields.length).toBe(3);
+    for (const f of arrayFields) {
+      const v = decodeValueRep(f.valueRep);
+      const offset = Number(v.payload);
+      expect(offset).toBeGreaterThan(USDC_BOOTSTRAP_SIZE);
+      expect(offset).toBeLessThan(bytes.length);
+    }
+  });
+});
+
+describe('adaptUsdNodeTree — properties report', () => {
+  it('records every visited property, marking unsupported keys without aborting', () => {
+    const root = new UsdNode('/Root', 'Xform');
+    root.setProperty('uniform token[] xformOpOrder', ['xformOp:translate']);
+    root.setProperty('material:binding', '<x>');
+    root.setProperty('prepend apiSchemas', ['MaterialBindingAPI']);
+
+    const builder = new UsdcLayerBuilder();
+    const report = adaptUsdNodeTree(root, builder);
+    expect(report.properties.length).toBe(3);
+    const unsupported = report.properties.filter((p) => !p.emitted);
+    expect(unsupported.length).toBe(2);
+    for (const u of unsupported) expect(u.reason).toBeDefined();
+  });
+});

--- a/src/converters/shared/usd-packaging.ts
+++ b/src/converters/shared/usd-packaging.ts
@@ -14,6 +14,7 @@ import {
   type StreamingUsdzFile,
 } from './usdz-stream-writer';
 import { getTextureFileBasename } from '../gltf/extensions/processors/texture-utils';
+import { encodeUsdNodeTreeToUsdc } from './usdc/usd-node-adapter';
 
 /**
  * Selects the on-disk format for the per-layer files inside the USDZ
@@ -53,6 +54,34 @@ export interface PackageContent {
   usdContent: string | Generator<string>;
   geometryFiles: Map<string, ArrayBuffer>;
   textureFiles: Map<string, ArrayBuffer>;
+  /**
+   * Optional source `UsdNode` for the root layer. Required to opt into
+   * `layerFormat: 'usdc'` — the binary encoder needs the structured tree,
+   * not the serialized USDA text. When omitted (or when the encoder reports
+   * unsupported properties), the packager falls back to writing the
+   * `usdContent` string as `model.usda`.
+   */
+  usdContentNode?: import('../../core/usd-node').UsdNode;
+}
+
+/**
+ * Try to build a binary USDC root layer from `content.usdContentNode`.
+ *
+ * Returns the encoded bytes when the adapter handled every property in the
+ * tree, or `null` when:
+ *   - `usdContentNode` was not supplied (caller didn't opt in), or
+ *   - the adapter encountered a property it doesn't yet support (in which
+ *     case the bytes would silently differ from the USDA source).
+ *
+ * In either case the packager falls back to writing USDA text. The fallback
+ * is intentional and safe — it's how `layerFormat: 'usdc'` ships before the
+ * adapter learns every USDA shape.
+ */
+function tryBuildUsdcRootLayer(content: PackageContent): Uint8Array | null {
+  if (!content.usdContentNode) return null;
+  const result = encodeUsdNodeTreeToUsdc(content.usdContentNode);
+  if (result.report.skipped > 0) return null;
+  return result.bytes;
 }
 
 /**
@@ -63,14 +92,46 @@ export interface PackageContent {
  * (`createUsdzPackageToStream` / `createUsdzPackageToFile`) packagers so the
  * file ordering and dedup rules cannot drift between the two paths.
  *
+ * `config?.layerFormat`:
+ *   - `'usda'` (default): write `model.usda` as text.
+ *   - `'usdc'`: try `tryBuildUsdcRootLayer`; if it succeeds, write
+ *     `model.usdc`. Otherwise fall back to USDA.
+ *
  * NOTE: if `content.usdContent` is a `Generator<string>` it will be exhausted
  * in this call. Generators are single-use; callers that need to re-package the
  * same content should pass a string or a fresh generator on each call.
  */
-function buildPackageFiles(content: PackageContent): StreamingUsdzFile[] {
+function buildPackageFiles(
+  content: PackageContent,
+  config?: PackageConfig
+): StreamingUsdzFile[] {
   const files: StreamingUsdzFile[] = [];
 
-  // Main USD file
+  // Main USD file — try binary first when requested, fall back to text.
+  if (config?.layerFormat === 'usdc') {
+    const usdcBytes = tryBuildUsdcRootLayer(content);
+    if (usdcBytes) {
+      const usdcName = USD_FILE_NAMES.MODEL.replace(/\.usda$/, '.usdc');
+      files.push({ name: usdcName, data: usdcBytes });
+      // Fall through into the geometry/texture loop below.
+      for (const [geometryPath, geometryData] of content.geometryFiles) {
+        files.push({ name: geometryPath, data: new Uint8Array(geometryData) });
+      }
+      const writtenTexturePaths = new Set<string>();
+      for (const [textureId, textureData] of content.textureFiles) {
+        const textureExtension = getTextureExtensionFromData(textureData);
+        const basename = getTextureFileBasename(textureId);
+        const textureName = `${USD_DEFAULT_NAMES.TEXTURE_PREFIX}${basename}.${textureExtension}`;
+        const texturePath = `${DIRECTORY_NAMES.TEXTURES}/${textureName}`;
+        if (writtenTexturePaths.has(texturePath)) continue;
+        writtenTexturePaths.add(texturePath);
+        files.push({ name: texturePath, data: new Uint8Array(textureData) });
+      }
+      return files;
+    }
+    // Fell through — emit USDA below.
+  }
+
   let usdContentChunks: Uint8Array[];
   if (typeof content.usdContent === 'string') {
     usdContentChunks = [new TextEncoder().encode(content.usdContent)];
@@ -117,7 +178,7 @@ export async function createUsdzPackage(
   content: PackageContent,
   config?: PackageConfig
 ): Promise<Blob> {
-  const files = buildPackageFiles(content);
+  const files = buildPackageFiles(content, config);
 
   // Create ZIP writer with proper alignment for optimal performance
   const zipWriter = new UsdzZipWriter({
@@ -152,6 +213,11 @@ export interface UsdzStreamOptions {
    * requirement. Defaults to `true`. Disable only for diagnostic purposes.
    */
   alignTo64Bytes?: boolean;
+  /**
+   * On-disk format for the per-layer files. Same semantics as
+   * `PackageConfig.layerFormat` — defaults to `'usda'`.
+   */
+  layerFormat?: LayerFormat;
 }
 
 /**
@@ -193,7 +259,10 @@ export async function createUsdzPackageToStream(
   output: Writable,
   options: UsdzStreamOptions = {}
 ): Promise<UsdzStreamResult> {
-  const files = buildPackageFiles(content);
+  const files = buildPackageFiles(
+    content,
+    options.layerFormat ? { layerFormat: options.layerFormat } : undefined
+  );
   return writeUsdzToStream(files, output, {
     alignTo64Bytes: options.alignTo64Bytes ?? true,
   });
@@ -212,7 +281,10 @@ export async function createUsdzPackageToFile(
   filePath: string,
   options: UsdzStreamOptions = {}
 ): Promise<UsdzStreamResult> {
-  const files = buildPackageFiles(content);
+  const files = buildPackageFiles(
+    content,
+    options.layerFormat ? { layerFormat: options.layerFormat } : undefined
+  );
   return writeUsdzToFile(files, filePath, {
     alignTo64Bytes: options.alignTo64Bytes ?? true,
   });

--- a/src/converters/shared/usdc/property-parser.ts
+++ b/src/converters/shared/usdc/property-parser.ts
@@ -1,0 +1,154 @@
+/** WebUsdFramework.Converters.Shared.Usdc.PropertyParser — parses the
+ *  type-prefixed property keys that `UsdNode.setProperty` accepts (e.g.
+ *  `"point3f[] points"`, `"uniform token info:id"`) into a structured
+ *  descriptor the USDC encoder can switch on.
+ *
+ * UsdNode property keys are a USDA-style line head: zero or more space-
+ * separated *qualifiers* (`uniform`, `prepend`, `varying`, …) followed by
+ * exactly one *type* token (`float`, `point3f[]`, `token[]`, …) followed by
+ * the property name (which may contain `:` and `.` characters).
+ *
+ * Examples:
+ *
+ *   "point3f[] points"                              → type=Vec3f[], name=points
+ *   "color3f[] primvars:displayColor"               → type=Vec3f[], name=primvars:displayColor
+ *   "uniform token primvars:displayColor:interpolation" → uniform Token, name=primvars:displayColor:interpolation
+ *   "float inputs:roughness"                        → type=Float, name=inputs:roughness
+ *   "prepend apiSchemas"                            → metadata, name=apiSchemas
+ *
+ * Some keys aren't typed attributes — `prepend references`,
+ * `material:binding`, `token outputs:surface.connect` describe relationships,
+ * connections, or list-ops. Those are returned with `kind: 'unsupported'`
+ * so the caller can fall back to the USDA path until the encoder learns the
+ * extra cases.
+ */
+
+import { CrateDataType } from './value-rep';
+
+/** Type-tagged result — what the encoder needs to do with this property. */
+export type ParsedProperty =
+  | {
+    kind: 'attribute';
+    name: string;
+    type: CrateDataType;
+    isArray: boolean;
+    isUniform: boolean;
+  }
+  | {
+    kind: 'unsupported';
+    /** The original key, kept verbatim so the caller can log / route it. */
+    raw: string;
+    reason: string;
+  };
+
+/** Map from a single USD type token to the corresponding CrateDataType. */
+const TYPE_MAP: Record<string, { type: CrateDataType; isArray: boolean }> = {
+  // Scalars
+  bool: { type: CrateDataType.Bool, isArray: false },
+  uchar: { type: CrateDataType.UChar, isArray: false },
+  int: { type: CrateDataType.Int, isArray: false },
+  uint: { type: CrateDataType.UInt, isArray: false },
+  int64: { type: CrateDataType.Int64, isArray: false },
+  uint64: { type: CrateDataType.UInt64, isArray: false },
+  half: { type: CrateDataType.Half, isArray: false },
+  float: { type: CrateDataType.Float, isArray: false },
+  double: { type: CrateDataType.Double, isArray: false },
+  string: { type: CrateDataType.String, isArray: false },
+  token: { type: CrateDataType.Token, isArray: false },
+  asset: { type: CrateDataType.AssetPath, isArray: false },
+
+  // Vec3f-family — color3f and normal3f and point3f all serialize as Vec3f.
+  vector3f: { type: CrateDataType.Vec3f, isArray: false },
+  point3f: { type: CrateDataType.Vec3f, isArray: false },
+  normal3f: { type: CrateDataType.Vec3f, isArray: false },
+  color3f: { type: CrateDataType.Vec3f, isArray: false },
+  float3: { type: CrateDataType.Vec3f, isArray: false },
+
+  // Vec2f
+  texCoord2f: { type: CrateDataType.Vec2f, isArray: false },
+  float2: { type: CrateDataType.Vec2f, isArray: false },
+
+  // Vec4f
+  color4f: { type: CrateDataType.Vec4f, isArray: false },
+  float4: { type: CrateDataType.Vec4f, isArray: false },
+
+  // Quatf
+  quatf: { type: CrateDataType.Quatf, isArray: false },
+};
+
+/** Tokens that are qualifiers, not type names. Order in the key doesn't matter. */
+const QUALIFIER_TOKENS = new Set(['uniform', 'varying', 'custom']);
+
+/**
+ * Parse a single UsdNode property key into a structured descriptor.
+ *
+ * The grammar is roughly: `(qualifier ' ')* type ' ' name`. Anything that
+ * doesn't parse is returned as `unsupported` so the caller can route it
+ * elsewhere.
+ */
+export function parsePropertyKey(rawKey: string): ParsedProperty {
+  const key = rawKey.trim();
+  if (key.length === 0) {
+    return { kind: 'unsupported', raw: rawKey, reason: 'empty key' };
+  }
+
+  // Reject metadata-style keys outright — these don't fit the attribute grammar.
+  if (key.startsWith('prepend ') || key.startsWith('append ')) {
+    return {
+      kind: 'unsupported',
+      raw: rawKey,
+      reason: `list-op metadata (\"${key.split(' ')[0]}\") is not yet supported`,
+    };
+  }
+  if (key.endsWith('.connect')) {
+    return { kind: 'unsupported', raw: rawKey, reason: 'attribute connection' };
+  }
+  if (key.startsWith('material:binding') || key.startsWith('rel ')) {
+    return { kind: 'unsupported', raw: rawKey, reason: 'relationship' };
+  }
+
+  // Tokenize on whitespace and pull qualifiers from the front.
+  const tokens = key.split(/\s+/);
+  let isUniform = false;
+  let cursor = 0;
+  while (cursor < tokens.length && QUALIFIER_TOKENS.has(tokens[cursor])) {
+    if (tokens[cursor] === 'uniform') isUniform = true;
+    cursor++;
+  }
+
+  if (cursor >= tokens.length - 0) {
+    // No type/name tokens left.
+    return { kind: 'unsupported', raw: rawKey, reason: 'missing type token' };
+  }
+
+  // Next token is the type (possibly with `[]` array suffix).
+  const typeToken = tokens[cursor++];
+  if (cursor >= tokens.length) {
+    return { kind: 'unsupported', raw: rawKey, reason: 'missing name after type' };
+  }
+  const name = tokens.slice(cursor).join(' ');
+
+  let typeStem = typeToken;
+  let isArray = false;
+  if (typeToken.endsWith('[]')) {
+    typeStem = typeToken.slice(0, -2);
+    isArray = true;
+  }
+
+  const mapped = TYPE_MAP[typeStem];
+  if (!mapped) {
+    return {
+      kind: 'unsupported',
+      raw: rawKey,
+      reason: `unknown type token "${typeToken}"`,
+    };
+  }
+
+  return {
+    kind: 'attribute',
+    name,
+    type: mapped.type,
+    isArray,
+    isUniform,
+  };
+}

--- a/src/converters/shared/usdc/usd-node-adapter.ts
+++ b/src/converters/shared/usdc/usd-node-adapter.ts
@@ -1,0 +1,258 @@
+/** WebUsdFramework.Converters.Shared.Usdc.UsdNodeAdapter — translate a
+ *  `UsdNode` scene-graph tree into a `UsdcLayerBuilder` invocation
+ *  sequence so the existing converters can opt into binary output without
+ *  changing how they construct the scene.
+ *
+ * The converters today build USDA-shaped `UsdNode` trees and call
+ * `serializeToUsda()` to produce text. With this adapter, the same tree can
+ * be fed into `UsdcLayerBuilder` to produce equivalent binary bytes.
+ *
+ * The adapter handles the property shapes the live converters actually emit
+ * (point3f[] arrays, float scalars, token attributes, …). Anything outside
+ * that subset (relationships, list-ops, connections, scalar Vec3f literals
+ * stored as USDA strings) is marked `unsupported` so the caller can decide
+ * whether to skip it or fall back to USDA output for the whole layer.
+ */
+
+import { UsdNode } from '../../../core/usd-node';
+import { UsdcLayerBuilder, type PrimHandle } from './layer-builder';
+import { parsePropertyKey, type ParsedProperty } from './property-parser';
+import { CrateDataType } from './value-rep';
+
+/** What happened to one property as the adapter walked it. */
+export interface AdaptedProperty {
+  rawKey: string;
+  /** `true` if the adapter encoded the property; `false` if it was skipped. */
+  emitted: boolean;
+  /** Human-readable explanation when `emitted` is `false`. */
+  reason?: string;
+}
+
+/** Summary of a tree adaptation pass. */
+export interface AdaptationReport {
+  /** Number of prims declared. */
+  primCount: number;
+  /** Per-property outcomes (every property that was visited). */
+  properties: AdaptedProperty[];
+  /** Number of properties skipped (`reason` set). Convenience aggregate. */
+  skipped: number;
+}
+
+/**
+ * Encode `root` and every descendant into `builder`. The root must be an
+ * `Xform`-typed prim (or compatible); the adapter declares it under the
+ * pseudo-root and walks its children depth-first.
+ *
+ * Returns a report listing every property the walker saw and whether the
+ * builder accepted it. Callers that need byte-for-byte parity with USDA
+ * should treat any `report.skipped > 0` as a signal to fall back.
+ */
+export function adaptUsdNodeTree(root: UsdNode, builder: UsdcLayerBuilder): AdaptationReport {
+  const report: AdaptationReport = {
+    primCount: 0,
+    properties: [],
+    skipped: 0,
+  };
+
+  function visit(node: UsdNode, parentPath: string | null): void {
+    // The builder owns the pseudo-root, so we anchor every top-level node
+    // either under '/' or under its parent's path.
+    const nodePath = node.getPath();
+    const handle = builder.declarePrim(nodePath, node.getTypeName());
+    report.primCount++;
+
+    for (const prop of node.getProperties()) {
+      const result = applyProperty(builder, handle, prop.key, prop.value);
+      if (!result.emitted) report.skipped++;
+      report.properties.push(result);
+    }
+
+    for (const child of node.getChildren()) visit(child, nodePath);
+  }
+
+  visit(root, null);
+  return report;
+}
+
+/**
+ * Apply a single property to the builder. Pure function — no I/O, no
+ * exceptions on unsupported inputs (the unsupported case returns a
+ * descriptive AdaptedProperty instead).
+ */
+export function applyProperty(
+  builder: UsdcLayerBuilder,
+  prim: PrimHandle,
+  key: string,
+  value: unknown
+): AdaptedProperty {
+  const parsed = parsePropertyKey(key);
+  if (parsed.kind === 'unsupported') {
+    return { rawKey: key, emitted: false, reason: parsed.reason };
+  }
+  return applyTypedAttribute(builder, prim, parsed, value, key);
+}
+
+function applyTypedAttribute(
+  builder: UsdcLayerBuilder,
+  prim: PrimHandle,
+  parsed: Extract<ParsedProperty, { kind: 'attribute' }>,
+  value: unknown,
+  rawKey: string
+): AdaptedProperty {
+  const { name, type, isArray } = parsed;
+  if (isArray) {
+    return applyArrayAttribute(builder, prim, name, type, value, rawKey);
+  }
+  return applyScalarAttribute(builder, prim, name, type, value, rawKey);
+}
+
+function applyScalarAttribute(
+  builder: UsdcLayerBuilder,
+  prim: PrimHandle,
+  name: string,
+  type: CrateDataType,
+  value: unknown,
+  rawKey: string
+): AdaptedProperty {
+  switch (type) {
+    case CrateDataType.Float: {
+      const n = coerceFiniteNumber(value);
+      if (n === null) return skipped(rawKey, `non-numeric value for float scalar`);
+      builder.addFloatAttribute(prim, name, n);
+      return { rawKey, emitted: true };
+    }
+    case CrateDataType.Int: {
+      const n = coerceInteger(value);
+      if (n === null) return skipped(rawKey, `non-integer value for int scalar`);
+      builder.addIntAttribute(prim, name, n);
+      return { rawKey, emitted: true };
+    }
+    case CrateDataType.Token: {
+      // Token values are always interned as strings; an empty string is
+      // valid (e.g. `token outputs:surface`).
+      const s = typeof value === 'string' ? value : value == null ? '' : String(value);
+      builder.addTokenAttribute(prim, name, s);
+      return { rawKey, emitted: true };
+    }
+    default:
+      return skipped(rawKey, `scalar type ${CrateDataType[type as unknown as number] ?? type} not yet supported`);
+  }
+}
+
+function applyArrayAttribute(
+  builder: UsdcLayerBuilder,
+  prim: PrimHandle,
+  name: string,
+  type: CrateDataType,
+  value: unknown,
+  rawKey: string
+): AdaptedProperty {
+  switch (type) {
+    case CrateDataType.Float: {
+      const arr = coerceFloat32Array(value);
+      if (!arr) return skipped(rawKey, 'float[] expected Float32Array or numeric array');
+      builder.addFloatArrayAttribute(prim, name, arr);
+      return { rawKey, emitted: true };
+    }
+    case CrateDataType.Vec3f: {
+      const arr = coerceFloat32Array(value);
+      if (!arr) return skipped(rawKey, 'Vec3f[] expected Float32Array or numeric array');
+      if (arr.length % 3 !== 0) {
+        return skipped(rawKey, `Vec3f[] length ${arr.length} not a multiple of 3`);
+      }
+      builder.addVec3fArrayAttribute(prim, name, arr);
+      return { rawKey, emitted: true };
+    }
+    case CrateDataType.Int: {
+      const arr = coerceInt32Array(value);
+      if (!arr) return skipped(rawKey, 'int[] expected Int32Array or integer array');
+      builder.addIntArrayAttribute(prim, name, arr);
+      return { rawKey, emitted: true };
+    }
+    case CrateDataType.Token: {
+      const arr = coerceStringArray(value);
+      if (!arr) return skipped(rawKey, 'token[] expected string array');
+      builder.addTokenArrayAttribute(prim, name, arr);
+      return { rawKey, emitted: true };
+    }
+    default:
+      return skipped(
+        rawKey,
+        `array type ${CrateDataType[type as unknown as number] ?? type} not yet supported`
+      );
+  }
+}
+
+function coerceFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function coerceInteger(value: unknown): number | null {
+  const n = coerceFiniteNumber(value);
+  if (n === null) return null;
+  if (!Number.isInteger(n)) return null;
+  return n;
+}
+
+function coerceFloat32Array(value: unknown): Float32Array | null {
+  if (value instanceof Float32Array) return value;
+  if (Array.isArray(value)) {
+    // Reject if any element isn't a finite number.
+    const out = new Float32Array(value.length);
+    for (let i = 0; i < value.length; i++) {
+      const v = value[i];
+      if (typeof v !== 'number' || !Number.isFinite(v)) return null;
+      out[i] = v;
+    }
+    return out;
+  }
+  return null;
+}
+
+function coerceInt32Array(value: unknown): Int32Array | null {
+  if (value instanceof Int32Array) return value;
+  if (value instanceof Uint32Array) return new Int32Array(value);
+  if (Array.isArray(value)) {
+    const out = new Int32Array(value.length);
+    for (let i = 0; i < value.length; i++) {
+      const v = value[i];
+      if (typeof v !== 'number' || !Number.isInteger(v)) return null;
+      out[i] = v | 0;
+    }
+    return out;
+  }
+  return null;
+}
+
+function coerceStringArray(value: unknown): string[] | null {
+  if (Array.isArray(value)) {
+    for (const v of value) if (typeof v !== 'string') return null;
+    return value as string[];
+  }
+  return null;
+}
+
+function skipped(rawKey: string, reason: string): AdaptedProperty {
+  return { rawKey, emitted: false, reason };
+}
+
+/**
+ * Convenience: build a USDC layer for the given root node in one call.
+ *
+ * Returns the encoded bytes plus the adaptation report. Callers can inspect
+ * `report.skipped` to decide whether the resulting bytes are a faithful
+ * representation of the source tree.
+ */
+export function encodeUsdNodeTreeToUsdc(root: UsdNode): {
+  bytes: Uint8Array;
+  report: AdaptationReport;
+} {
+  const builder = new UsdcLayerBuilder();
+  const report = adaptUsdNodeTree(root, builder);
+  return { bytes: builder.serialize(), report };
+}

--- a/src/converters/shared/usdc/usd-node-adapter.ts
+++ b/src/converters/shared/usdc/usd-node-adapter.ts
@@ -54,11 +54,8 @@ export function adaptUsdNodeTree(root: UsdNode, builder: UsdcLayerBuilder): Adap
     skipped: 0,
   };
 
-  function visit(node: UsdNode, parentPath: string | null): void {
-    // The builder owns the pseudo-root, so we anchor every top-level node
-    // either under '/' or under its parent's path.
-    const nodePath = node.getPath();
-    const handle = builder.declarePrim(nodePath, node.getTypeName());
+  function visit(node: UsdNode): void {
+    const handle = builder.declarePrim(node.getPath(), node.getTypeName());
     report.primCount++;
 
     for (const prop of node.getProperties()) {
@@ -67,10 +64,10 @@ export function adaptUsdNodeTree(root: UsdNode, builder: UsdcLayerBuilder): Adap
       report.properties.push(result);
     }
 
-    for (const child of node.getChildren()) visit(child, nodePath);
+    for (const child of node.getChildren()) visit(child);
   }
 
-  visit(root, null);
+  visit(root);
   return report;
 }
 
@@ -135,7 +132,7 @@ function applyScalarAttribute(
       return { rawKey, emitted: true };
     }
     default:
-      return skipped(rawKey, `scalar type ${CrateDataType[type as unknown as number] ?? type} not yet supported`);
+      return skipped(rawKey, `scalar type ${describeType(type)} not yet supported`);
   }
 }
 
@@ -176,10 +173,7 @@ function applyArrayAttribute(
       return { rawKey, emitted: true };
     }
     default:
-      return skipped(
-        rawKey,
-        `array type ${CrateDataType[type as unknown as number] ?? type} not yet supported`
-      );
+      return skipped(rawKey, `array type ${describeType(type)} not yet supported`);
   }
 }
 
@@ -239,6 +233,14 @@ function coerceStringArray(value: unknown): string[] | null {
 
 function skipped(rawKey: string, reason: string): AdaptedProperty {
   return { rawKey, emitted: false, reason };
+}
+
+/** Find the CrateDataType name corresponding to a numeric value, for error messages. */
+function describeType(type: CrateDataType): string {
+  for (const [name, v] of Object.entries(CrateDataType)) {
+    if (v === type) return name;
+  }
+  return String(type);
 }
 
 /**

--- a/src/core/usd-node.ts
+++ b/src/core/usd-node.ts
@@ -167,6 +167,20 @@ export class UsdNode {
   }
 
   /**
+   * Iterate every property attached to this node, in insertion order.
+   *
+   * Yields a stable read-only view of each `{ key, value, type }` triple so
+   * callers (e.g. the USDC adapter) can switch on the key shape without
+   * reaching into internal state. The yielded objects are detached copies —
+   * mutating them does not affect the node.
+   */
+  *getProperties(): IterableIterator<Readonly<USDProperty>> {
+    for (const p of this._properties) {
+      yield { key: p.key, value: p.value, type: p.type };
+    }
+  }
+
+  /**
    * Set a time-sampled property for animation
    */
   setTimeSampledProperty(key: string, timeSamples: Map<number, string>, type: string): this {


### PR DESCRIPTION
## Summary

Lights up the `layerFormat: 'usdc'` flag from #122/#123 by adding the
`UsdNode → UsdcLayerBuilder` adapter and wiring it into the packaging
pipeline. Callers that already build the scene as a `UsdNode` tree can now
emit a binary `model.usdc` root layer inside the USDZ archive simply by
opting in.

## What lands here (4 focused commits)

1. **`parsePropertyKey`** — splits USDA-style property keys (e.g.
   `"point3f[] points"`, `"uniform token info:id"`) into a structured
   `ParsedProperty` descriptor. 21 tests.
2. **`UsdNode.getProperties()` iterator** — exposes the property list
   read-only so the adapter can walk every node without reaching into
   private state.
3. **`UsdNode → UsdcLayerBuilder` adapter** — depth-first walker that
   declares each prim and dispatches every property to the right
   `add*Attribute` helper based on the type descriptor. Handles the shapes
   the live PLY/OBJ/STL/GLB converters emit (Float / Int / Token scalars;
   Vec3f / Float / Int / Token arrays). Unsupported keys (relationships,
   list-ops, connections) are recorded in the report but do not abort the
   walk. 19 tests.
4. **Pipeline wiring** — `PackageContent.usdContentNode` (optional),
   `PackageConfig.layerFormat` honored in `buildPackageFiles`. When
   `'usdc'` is requested + the source tree is supplied + the adapter
   reports zero skipped properties, the root layer becomes `model.usdc`.
   Otherwise the packager falls back to `model.usda` — this fallback is
   what makes the flag safe to enable today. 6 integration tests.

## What does NOT land here

- **Per-converter opt-in**: GLB / PLY / OBJ / STL converters still build
  USDA strings and don't yet pass `usdContentNode`. They can opt in
  individually in follow-ups by adding `usdContentNode: rootNode` to the
  `PackageContent` they hand to the packager.
- **Geometry-layer (`Geometries/geom_N.usda`) USDC encoding**: the
  packager only encodes the root layer as USDC right now. The geometry
  layers remain text. Adding USDC support there is structurally identical
  but requires the geometry-builder to expose its `UsdNode` tree (similar
  to the root-layer change here).
- **`usdcat` byte-level validation**: the encoder structurally
  round-trips through its own decoder; cross-validation against
  fixtures produced by Apple's reference reader is the gating step
  before flipping `layerFormat`'s default to `'usdc'`.

## Test plan

- [x] All 280 tests pass (`pnpm run test:run`)
- [x] Type-check clean (`pnpm run type-check`)
- [x] 46 new tests across the 3 new modules (parser 21, adapter 19, pipeline integration 6)
- [ ] Follow-up: have a converter opt in (PLY first — simplest scene shapes)
- [ ] Follow-up: validate emitted model.usdc loads in macOS QuickLook / `usdcat`

Refs #122