### PR TITLE
feat(usdc): per-converter layerFormat opt-in (PLY) + Vec3f USDA parsing

### DIFF
--- a/src/__tests__/usdc-ply-end-to-end.test.ts
+++ b/src/__tests__/usdc-ply-end-to-end.test.ts
@@ -1,0 +1,98 @@
+/**
+ * End-to-end PLY → USDZ tests with `layerFormat: 'usdc'`.
+ *
+ * The converter accepts the new `layerFormat` option and threads both the
+ * serialized USDA text and the source `UsdNode` tree through to the
+ * packager. The packager:
+ *   - On `'usda'` (default): writes `model.usda` as today.
+ *   - On `'usdc'`: tries the UsdNode → USDC adapter; if every property
+ *     in the root tree is supported, writes `model.usdc`. If the tree
+ *     contains shapes the adapter cannot encode yet (e.g. relationships,
+ *     list-ops, attribute connections), the packager silently falls back
+ *     to `model.usda` so output stays correct.
+ *
+ * These tests:
+ *   - confirm the option is accepted by `convertPlyToUsdz`,
+ *   - confirm the resulting archive is a valid USDZ in both modes,
+ *   - record the current state (root layer falls back to USDA because
+ *     the PLY scene includes material binding + connection + apiSchemas
+ *     list-op — the adapter does not yet emit those types).
+ */
+import { describe, it, expect } from 'vitest';
+import { convertPlyToUsdz } from '../converters/ply/ply-converter';
+
+const MINIMAL_PLY_BUFFER: ArrayBuffer = new TextEncoder().encode(
+  [
+    'ply',
+    'format ascii 1.0',
+    'element vertex 3',
+    'property float x',
+    'property float y',
+    'property float z',
+    'end_header',
+    '0.0 0.0 0.0',
+    '1.0 0.0 0.0',
+    '0.0 1.0 0.0',
+    '',
+  ].join('\n')
+).buffer as ArrayBuffer;
+
+async function readArchiveNames(blob: Blob): Promise<string[]> {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const names: string[] = [];
+  let cursor = 0;
+  while (cursor + 4 <= bytes.length) {
+    const sig = view.getUint32(cursor, true);
+    if (sig !== 0x04034b50) break;
+    const nameLen = view.getUint16(cursor + 26, true);
+    const extraLen = view.getUint16(cursor + 28, true);
+    const compressedSize = view.getUint32(cursor + 18, true);
+    const name = new TextDecoder().decode(
+      bytes.subarray(cursor + 30, cursor + 30 + nameLen)
+    );
+    names.push(name);
+    cursor += 30 + nameLen + extraLen + compressedSize;
+  }
+  return names;
+}
+
+describe('PLY → USDZ — layerFormat option', () => {
+  it('default writes model.usda', async () => {
+    const blob = await convertPlyToUsdz(MINIMAL_PLY_BUFFER);
+    const names = await readArchiveNames(blob);
+    expect(names).toContain('model.usda');
+    expect(names).not.toContain('model.usdc');
+  });
+
+  it('explicit layerFormat: "usda" writes model.usda', async () => {
+    const blob = await convertPlyToUsdz(MINIMAL_PLY_BUFFER, undefined, {
+      layerFormat: 'usda',
+    });
+    const names = await readArchiveNames(blob);
+    expect(names).toContain('model.usda');
+  });
+
+  it('layerFormat: "usdc" produces a valid USDZ archive (falls back to USDA when adapter cannot encode the full tree)', async () => {
+    // The PLY converter currently emits material binding + outputs:surface
+    // connection + prepend apiSchemas — none of which the adapter can yet
+    // encode. The packager falls back to USDA, but the archive itself must
+    // remain valid and readable.
+    const blob = await convertPlyToUsdz(MINIMAL_PLY_BUFFER, undefined, {
+      layerFormat: 'usdc',
+    });
+    const names = await readArchiveNames(blob);
+    expect(names.length).toBeGreaterThan(0);
+    // Either model.usdc (adapter succeeded) or model.usda (fallback) is fine;
+    // both are valid USDZ contents. The point is that the option threads
+    // through without crashing and the archive is well-formed.
+    expect(names.some((n) => n === 'model.usdc' || n === 'model.usda')).toBe(true);
+
+    // First file should always start with the ZIP local-file-header magic.
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    expect(bytes[0]).toBe(0x50);
+    expect(bytes[1]).toBe(0x4b);
+    expect(bytes[2]).toBe(0x03);
+    expect(bytes[3]).toBe(0x04);
+  });
+});

--- a/src/__tests__/usdc-usd-node-adapter.test.ts
+++ b/src/__tests__/usdc-usd-node-adapter.test.ts
@@ -91,12 +91,26 @@ describe('applyProperty — scalar dispatch', () => {
     expect(applyProperty(b, root, 'token outputs:surface', '').emitted).toBe(true);
   });
 
-  it('skips unsupported scalar Vec3f literals (would need USDA-string parsing)', () => {
+  it('parses USDA-formatted scalar Vec3f literals (color3f inputs:diffuseColor)', () => {
     const b = new UsdcLayerBuilder();
     const root = b.declarePrim('/Root', 'Material');
     const r = applyProperty(b, root, 'color3f inputs:diffuseColor', '(0.7, 0.7, 0.7)');
+    expect(r.emitted).toBe(true);
+  });
+
+  it('skips malformed Vec3f scalar literals', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Material');
+    const r = applyProperty(b, root, 'color3f inputs:diffuseColor', '(not, a, tuple)');
     expect(r.emitted).toBe(false);
-    expect(r.reason).toBeDefined();
+  });
+
+  it('parses USDA-formatted Vec3f[] literals (float3[] extent)', () => {
+    const b = new UsdcLayerBuilder();
+    b.declarePrim('/Root', 'Xform');
+    const root = b.declarePrim('/Root/Mesh', 'Mesh');
+    const r = applyProperty(b, root, 'float3[] extent', '[(-1, -1, -1), (1, 1, 1)]');
+    expect(r.emitted).toBe(true);
   });
 
   it('skips connection / relationship / list-op keys', () => {

--- a/src/__tests__/usdc-usda-value-parser.test.ts
+++ b/src/__tests__/usdc-usda-value-parser.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the USDA literal parser used by the UsdNode → USDC adapter.
+ *
+ * The converters store several property values as USDA-formatted strings
+ * (e.g. `"(0.7, 0.7, 0.7)"` for color3f scalars, `"[(...), (...)]"` for
+ * `float3[] extent`). These parsers turn them into the typed numeric
+ * arrays the USDC encoders consume. The tests cover the happy paths plus
+ * the malformed-input rejections.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseVec3fScalar,
+  parseVec2fScalar,
+  parseVec3fArray,
+} from '../converters/shared/usdc/usda-value-parser';
+
+describe('parseVec3fScalar', () => {
+  it('parses a basic 3-tuple', () => {
+    const out = parseVec3fScalar('(0.7, 0.7, 0.7)');
+    expect(Array.from(out!)).toEqual([0.7, 0.7, 0.7].map((v) => Math.fround(v)));
+  });
+
+  it('tolerates whitespace and negative values', () => {
+    const out = parseVec3fScalar('(  -1.0 ,  0 , 2.5 )');
+    expect(Array.from(out!)).toEqual([-1.0, 0, 2.5]);
+  });
+
+  it('returns null when arity is wrong', () => {
+    expect(parseVec3fScalar('(1, 2)')).toBeNull();
+    expect(parseVec3fScalar('(1, 2, 3, 4)')).toBeNull();
+  });
+
+  it('returns null for non-numeric tokens', () => {
+    expect(parseVec3fScalar('(1, foo, 3)')).toBeNull();
+  });
+
+  it('returns null when parens are missing', () => {
+    expect(parseVec3fScalar('1, 2, 3')).toBeNull();
+    expect(parseVec3fScalar('(1, 2, 3')).toBeNull();
+    expect(parseVec3fScalar('1, 2, 3)')).toBeNull();
+  });
+});
+
+describe('parseVec2fScalar', () => {
+  it('parses a basic 2-tuple', () => {
+    expect(Array.from(parseVec2fScalar('(0.5, 0.75)')!)).toEqual([0.5, 0.75]);
+  });
+
+  it('rejects 3-tuples', () => {
+    expect(parseVec2fScalar('(1, 2, 3)')).toBeNull();
+  });
+});
+
+describe('parseVec3fArray', () => {
+  it('parses an empty array', () => {
+    const out = parseVec3fArray('[]');
+    expect(out).toBeInstanceOf(Float32Array);
+    expect(out!.length).toBe(0);
+  });
+
+  it('parses a single 3-tuple', () => {
+    expect(Array.from(parseVec3fArray('[(0, 0, 0)]')!)).toEqual([0, 0, 0]);
+  });
+
+  it('parses two tuples (the typical extent shape)', () => {
+    const out = parseVec3fArray('[(-1, -2, -3), (4, 5, 6)]');
+    expect(Array.from(out!)).toEqual([-1, -2, -3, 4, 5, 6]);
+  });
+
+  it('parses many tuples with mixed whitespace', () => {
+    const out = parseVec3fArray('[ (0,0,0) , (1,2,3),(4,5,6) ]');
+    expect(Array.from(out!)).toEqual([0, 0, 0, 1, 2, 3, 4, 5, 6]);
+  });
+
+  it('returns null when outer brackets are missing', () => {
+    expect(parseVec3fArray('(1,2,3)')).toBeNull();
+  });
+
+  it('returns null when an inner tuple has wrong arity', () => {
+    expect(parseVec3fArray('[(1,2,3), (4,5)]')).toBeNull();
+  });
+
+  it('returns null when parentheses are unbalanced', () => {
+    expect(parseVec3fArray('[(1,2,3)')).toBeNull();
+    expect(parseVec3fArray('[(1,2,3))]')).toBeNull();
+  });
+
+  it('returns null on non-numeric content', () => {
+    expect(parseVec3fArray('[(a, b, c)]')).toBeNull();
+  });
+});

--- a/src/converters/ply/ply-converter.ts
+++ b/src/converters/ply/ply-converter.ts
@@ -373,15 +373,21 @@ export async function convertPlyToUsdz(
       primType: meshData.isPointCloud ? 'Points' : 'Mesh',
     });
 
-    // Package
+    // Package — pass both the serialized USDA text and the source UsdNode
+    // tree so the packager can opt into USDC root layers when the caller
+    // asks for it. With layerFormat undefined or 'usda' (the default), the
+    // tree is ignored and the text path runs unchanged.
     const packageContent: PackageContent = {
       usdContent: rootNode.serializeToUsda(),
+      usdContentNode: rootNode,
       geometryFiles: new Map(),
       textureFiles: new Map(),
     };
 
     if (options?.outputPath) {
-      const result = await createUsdzPackageToFile(packageContent, options.outputPath);
+      const result = await createUsdzPackageToFile(packageContent, options.outputPath, {
+        ...(options.layerFormat ? { layerFormat: options.layerFormat } : {}),
+      });
       logger.info('USDZ conversion completed', {
         stage: 'conversion_complete',
         usdzSize: result.totalBytes,
@@ -391,7 +397,10 @@ export async function convertPlyToUsdz(
       return result;
     }
 
-    const usdzBlob = await createUsdzPackage(packageContent);
+    const usdzBlob = await createUsdzPackage(
+      packageContent,
+      options?.layerFormat ? { layerFormat: options.layerFormat } : undefined
+    );
 
     logger.info('USDZ conversion completed', {
       stage: 'conversion_complete',

--- a/src/converters/shared/usd-packaging.ts
+++ b/src/converters/shared/usd-packaging.ts
@@ -242,6 +242,14 @@ export interface ConvertOptions {
    * debug bundle including the archive blob, omit `outputPath`.
    */
   outputPath?: string;
+  /**
+   * On-disk format for the per-layer files inside the USDZ archive. The
+   * outer file is always `.usdz` regardless of this setting. Defaults to
+   * `'usda'`. See {@link LayerFormat} for the trade-offs and the safety
+   * net (the packager falls back to `'usda'` if any property in the source
+   * tree cannot be encoded).
+   */
+  layerFormat?: LayerFormat;
 }
 
 /**

--- a/src/converters/shared/usdc/array-values.ts
+++ b/src/converters/shared/usdc/array-values.ts
@@ -45,6 +45,14 @@ export interface EncodedArrayValue {
   isCompressed: boolean;
   /** Number of elements (used for sanity checks; not embedded in this struct). */
   count: number;
+  /**
+   * Whether the resulting ValueRep should set the `isArray` flag.
+   *
+   * Most external values are arrays (`Float[]`, `Vec3f[]`, `Int[]`), but some
+   * scalar values are too large for the 48-bit inlined payload and are stored
+   * externally with `isArray: false` (a single `Vec3f`, `Vec4f`, or matrix).
+   */
+  isArray: boolean;
 }
 
 /**
@@ -53,7 +61,7 @@ export interface EncodedArrayValue {
 export function arrayValueRep(value: EncodedArrayValue, fileOffset: number | bigint): bigint {
   return externalValueRep({
     type: value.type,
-    isArray: true,
+    isArray: value.isArray,
     isCompressed: value.isCompressed,
     fileOffset,
   });
@@ -116,7 +124,7 @@ export function encodeFloatArray(
   const view = new DataView(elementBytes.buffer);
   for (let i = 0; i < count; i++) view.setFloat32(i * 4, values[i], true);
   const { bytes, isCompressed } = packArray(count, elementBytes, opts?.compress);
-  return { bytes, type: CrateDataType.Float, isCompressed, count };
+  return { bytes, type: CrateDataType.Float, isCompressed, count, isArray: true };
 }
 
 /**
@@ -137,7 +145,35 @@ export function encodeVec3fArray(
   const view = new DataView(elementBytes.buffer);
   for (let i = 0; i < flat.length; i++) view.setFloat32(i * 4, flat[i], true);
   const { bytes, isCompressed } = packArray(count, elementBytes, opts?.compress);
-  return { bytes, type: CrateDataType.Vec3f, isCompressed, count };
+  return { bytes, type: CrateDataType.Vec3f, isCompressed, count, isArray: true };
+}
+
+/**
+ * Encode a single Vec3f scalar (3 × float32 = 12 bytes). Returned with
+ * `isArray: false` so the resulting ValueRep refers to a single value, not
+ * an array.
+ *
+ * The on-disk format is identical to `encodeVec3fArray` with count=1 (so the
+ * 8-byte count prefix + 12 bytes of data, uncompressed). The `isArray` flag
+ * on the ValueRep is the bit that distinguishes scalar from 1-element array.
+ */
+export function encodeVec3fScalar(x: number, y: number, z: number): EncodedArrayValue {
+  const elementBytes = new Uint8Array(12);
+  const view = new DataView(elementBytes.buffer);
+  view.setFloat32(0, x, true);
+  view.setFloat32(4, y, true);
+  view.setFloat32(8, z, true);
+  // Always uncompressed for a single Vec3f — 12 bytes is too small to compress.
+  const out = new Uint8Array(8 + 12);
+  new DataView(out.buffer).setBigUint64(0, 1n, true);
+  out.set(elementBytes, 8);
+  return {
+    bytes: out,
+    type: CrateDataType.Vec3f,
+    isCompressed: false,
+    count: 1,
+    isArray: false,
+  };
 }
 
 /** Encode an Int[] (signed 32-bit integers). */
@@ -150,7 +186,7 @@ export function encodeInt32Array(
   const view = new DataView(elementBytes.buffer);
   for (let i = 0; i < count; i++) view.setInt32(i * 4, values[i] | 0, true);
   const { bytes, isCompressed } = packArray(count, elementBytes, opts?.compress);
-  return { bytes, type: CrateDataType.Int, isCompressed, count };
+  return { bytes, type: CrateDataType.Int, isCompressed, count, isArray: true };
 }
 
 /**
@@ -171,7 +207,7 @@ export function encodeTokenArray(
     view.setUint32(i * 4, v, true);
   }
   const { bytes, isCompressed } = packArray(count, elementBytes, opts?.compress);
-  return { bytes, type: CrateDataType.Token, isCompressed, count };
+  return { bytes, type: CrateDataType.Token, isCompressed, count, isArray: true };
 }
 
 /**

--- a/src/converters/shared/usdc/layer-builder.ts
+++ b/src/converters/shared/usdc/layer-builder.ts
@@ -48,6 +48,7 @@ import {
   type EncodedArrayValue,
   encodeFloatArray,
   encodeVec3fArray,
+  encodeVec3fScalar,
   encodeInt32Array,
   encodeTokenArray,
   arrayValueRep,
@@ -243,6 +244,27 @@ export class UsdcLayerBuilder {
     flat: Float32Array | ReadonlyArray<number>
   ): void {
     const enc = encodeVec3fArray(flat);
+    const arrayId = this.pendingArrays.length;
+    this.pendingArrays.push({ encoded: enc });
+    const fieldTok = this.tokens.intern(name);
+    this.specBuilders[prim.pathIndex].fields.push({
+      tokenIndex: fieldTok,
+      rep: { kind: 'array', arrayId },
+    });
+  }
+
+  /**
+   * Add a Vec3f scalar attribute (color3f, normal3f, point3f single value).
+   * Stored externally — Vec3f doesn't fit in a 48-bit inlined ValueRep.
+   */
+  addVec3fAttribute(
+    prim: PrimHandle,
+    name: string,
+    x: number,
+    y: number,
+    z: number
+  ): void {
+    const enc = encodeVec3fScalar(x, y, z);
     const arrayId = this.pendingArrays.length;
     this.pendingArrays.push({ encoded: enc });
     const fieldTok = this.tokens.intern(name);

--- a/src/converters/shared/usdc/usd-node-adapter.ts
+++ b/src/converters/shared/usdc/usd-node-adapter.ts
@@ -18,6 +18,7 @@ import { UsdNode } from '../../../core/usd-node';
 import { UsdcLayerBuilder, type PrimHandle } from './layer-builder';
 import { parsePropertyKey, type ParsedProperty } from './property-parser';
 import { CrateDataType } from './value-rep';
+import { parseVec3fScalar, parseVec3fArray } from './usda-value-parser';
 
 /** What happened to one property as the adapter walked it. */
 export interface AdaptedProperty {
@@ -131,6 +132,22 @@ function applyScalarAttribute(
       builder.addTokenAttribute(prim, name, s);
       return { rawKey, emitted: true };
     }
+    case CrateDataType.Vec3f: {
+      // Two input shapes:
+      //   - USDA-formatted string `"(x, y, z)"` (color3f inputs:diffuseColor)
+      //   - typed Float32Array of length 3 (rare but cheap to support)
+      let triple: Float32Array | null = null;
+      if (typeof value === 'string') {
+        triple = parseVec3fScalar(value);
+      } else if (value instanceof Float32Array && value.length === 3) {
+        triple = value;
+      } else if (Array.isArray(value) && value.length === 3) {
+        triple = coerceFloat32Array(value);
+      }
+      if (!triple) return skipped(rawKey, 'Vec3f scalar expected (x,y,z) tuple');
+      builder.addVec3fAttribute(prim, name, triple[0], triple[1], triple[2]);
+      return { rawKey, emitted: true };
+    }
     default:
       return skipped(rawKey, `scalar type ${describeType(type)} not yet supported`);
   }
@@ -152,8 +169,17 @@ function applyArrayAttribute(
       return { rawKey, emitted: true };
     }
     case CrateDataType.Vec3f: {
-      const arr = coerceFloat32Array(value);
-      if (!arr) return skipped(rawKey, 'Vec3f[] expected Float32Array or numeric array');
+      // Three input shapes for Vec3f[]:
+      //   - typed Float32Array (point3f[] points, color3f[] primvars:displayColor)
+      //   - plain number[] (typed-array refusing callers)
+      //   - USDA-formatted string `"[(...), (...)]"` (float3[] extent)
+      let arr: Float32Array | null = null;
+      if (typeof value === 'string') {
+        arr = parseVec3fArray(value);
+      } else {
+        arr = coerceFloat32Array(value);
+      }
+      if (!arr) return skipped(rawKey, 'Vec3f[] expected Float32Array, numeric array, or USDA literal');
       if (arr.length % 3 !== 0) {
         return skipped(rawKey, `Vec3f[] length ${arr.length} not a multiple of 3`);
       }

--- a/src/converters/shared/usdc/usda-value-parser.ts
+++ b/src/converters/shared/usdc/usda-value-parser.ts
@@ -1,0 +1,102 @@
+/** WebUsdFramework.Converters.Shared.Usdc.UsdaValueParser — parse the
+ *  USDA-style string literals our converters store as property values into
+ *  the typed numeric arrays the USDC encoder consumes.
+ *
+ * The existing converters were written for the USDA text path, so several
+ * properties carry their values as USDA-formatted strings rather than typed
+ * arrays. The most common shapes:
+ *
+ *   "(0.7, 0.7, 0.7)"                    — scalar Vec3f (color3f input)
+ *   "[(min,min,min), (max,max,max)]"      — Vec3f[] of two (extent)
+ *   "(0.5, 0.7)"                          — scalar Vec2f
+ *
+ * These parsers are intentionally tolerant of whitespace and trailing
+ * commas; they reject anything that doesn't match the expected shape
+ * (returning `null`) so the adapter can route the property to the
+ * unsupported bucket without throwing.
+ */
+
+/** Parse a single USDA tuple `"(a, b, c, ...)"`. Returns the numbers, or null. */
+function parseTuple(input: string, expectedLength?: number): number[] | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith('(') || !trimmed.endsWith(')')) return null;
+  const inner = trimmed.slice(1, -1).trim();
+  if (inner.length === 0) return [];
+  const parts = inner.split(',').map((p) => p.trim()).filter((p) => p.length > 0);
+  const out: number[] = new Array(parts.length);
+  for (let i = 0; i < parts.length; i++) {
+    const n = Number(parts[i]);
+    if (!Number.isFinite(n)) return null;
+    out[i] = n;
+  }
+  if (expectedLength !== undefined && out.length !== expectedLength) return null;
+  return out;
+}
+
+/**
+ * Parse a USDA Vec3f scalar literal, e.g. `"(0.7, 0.7, 0.7)"`.
+ *
+ * Returns a 3-element `Float32Array` or `null` if the input is malformed.
+ */
+export function parseVec3fScalar(input: string): Float32Array | null {
+  const tuple = parseTuple(input, 3);
+  if (!tuple) return null;
+  return Float32Array.from(tuple);
+}
+
+/**
+ * Parse a USDA Vec2f scalar literal, e.g. `"(0.5, 0.7)"`.
+ */
+export function parseVec2fScalar(input: string): Float32Array | null {
+  const tuple = parseTuple(input, 2);
+  if (!tuple) return null;
+  return Float32Array.from(tuple);
+}
+
+/**
+ * Parse a USDA Vec3f[] array literal, e.g.
+ *   `"[(0,0,0), (1,1,1)]"`   → Float32Array(6) [0,0,0,1,1,1]
+ *   `"[]"`                    → Float32Array(0)
+ *
+ * Returns a flat interleaved `Float32Array` of length `3 × count`, or
+ * `null` if any tuple is malformed or has the wrong arity.
+ */
+export function parseVec3fArray(input: string): Float32Array | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return null;
+  const inner = trimmed.slice(1, -1).trim();
+  if (inner.length === 0) return new Float32Array(0);
+
+  // Split into individual `(...)` tuples. We can't use split(',') on the
+  // outer string because each tuple itself contains commas. Walk byte by
+  // byte instead, tracking parenthesis depth.
+  const tuples: string[] = [];
+  let depth = 0;
+  let start = -1;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (ch === '(') {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === ')') {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        tuples.push(inner.slice(start, i + 1));
+        start = -1;
+      } else if (depth < 0) {
+        return null;
+      }
+    }
+  }
+  if (depth !== 0) return null;
+
+  const flat: number[] = new Array(tuples.length * 3);
+  for (let t = 0; t < tuples.length; t++) {
+    const parsed = parseTuple(tuples[t], 3);
+    if (!parsed) return null;
+    flat[t * 3] = parsed[0];
+    flat[t * 3 + 1] = parsed[1];
+    flat[t * 3 + 2] = parsed[2];
+  }
+  return Float32Array.from(flat);
+}


### PR DESCRIPTION
## Summary

Continues #124 by lighting up the converter-level `layerFormat` option for
PLY and adding USDA-literal parsing for the two value shapes the existing
converters store as strings (Vec3f scalar and Vec3f[]). Callers can now
write:

```ts
await convertPlyToUsdz(buffer, undefined, { layerFormat: 'usdc' });
```

…and the packager threads the source UsdNode tree all the way down to
the binary encoder. When the adapter handles every property in the tree
the result is `model.usdc`; otherwise it falls back to `model.usda` —
the safety net that makes this safe to enable today.

## What lands here (3 focused commits)

1. **ConvertOptions.layerFormat plumbing** — type-only addition. Every
   per-format converter (`convertGlbToUsdz`, `convertPlyToUsdz`,
   `convertObjToUsdz`, `convertStlToUsdz`) and `WebUsdFramework.convert`
   already takes a `ConvertOptions`; now they share a single `layerFormat`
   field there too.
2. **USDA Vec3f parsing** — `parseVec3fScalar`, `parseVec2fScalar`,
   `parseVec3fArray` plus `encodeVec3fScalar` for the `isArray:false`
   path. The adapter now handles `color3f inputs:diffuseColor "(r,g,b)"`
   and `float3[] extent "[(...),(...)]"`. (15 parser tests + 3 adapter
   tests.)
3. **PLY converter wiring** — `convertPlyToUsdz` passes
   `usdContentNode: rootNode` in `PackageContent` and forwards
   `options.layerFormat` to the packager. (3 end-to-end tests.)

## Current behavior

For the PLY scene as it stands today, requesting `layerFormat: 'usdc'`
results in a fallback to `model.usda` because the PLY converter emits:
- `prepend apiSchemas` — TokenListOp (not yet supported)
- `material:binding` — Relationship spec (not yet supported)
- `outputs:surface.connect` — Connection spec (not yet supported)

These are the next three pieces to land. Each one is structurally
contained: TokenListOp is a value type addition, while Relationship
and Connection require new SdfSpecType branches in the layer builder
plus path-tree updates.

## Test plan

- [x] All 300 tests pass (`pnpm run test:run`)
- [x] Type-check clean (`pnpm run type-check`)
- [x] 21 new tests (15 USDA parser + 3 adapter Vec3f + 3 PLY end-to-end)
- [ ] Follow-up: TokenListOp value type (unblocks `prepend apiSchemas`)
- [ ] Follow-up: Relationship spec type (unblocks `material:binding`)
- [ ] Follow-up: Connection spec type (unblocks `outputs:surface.connect`)
- [ ] Follow-up: Once all three land, flip PLY's adapter from "falls back"
      to "succeeds" — and validate the resulting `model.usdc` loads in
      QuickLook / `usdcat`.

Refs #122