### PR TITLE
feat(usdc): TokenListOp value type + adapter dispatch

### DIFF
--- a/src/__tests__/usdc-listop-values.test.ts
+++ b/src/__tests__/usdc-listop-values.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the TokenListOp value encoder.
+ *
+ * Round-trip: every input shape that comes through `encodeTokenListOp`
+ * must decode back to the same logical value via `decodeTokenListOp`. The
+ * tests also lock down the byte layout so future encoder changes can't
+ * silently drift from the on-disk format.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  encodeTokenListOp,
+  decodeTokenListOp,
+  SdfListOpSubListType,
+  listOpValueRep,
+  type TokenListOpInput,
+} from '../converters/shared/usdc/listop-values';
+import { CrateDataType, decodeValueRep } from '../converters/shared/usdc/value-rep';
+
+function roundTrip(input: TokenListOpInput): TokenListOpInput {
+  return decodeTokenListOp(encodeTokenListOp(input).bytes);
+}
+
+describe('encodeTokenListOp — byte layout', () => {
+  it('emits a 2-byte header for an empty op', () => {
+    const enc = encodeTokenListOp({});
+    expect(enc.bytes.length).toBe(2);
+    expect(enc.bytes[0]).toBe(0); // isExplicit = false
+    expect(enc.bytes[1]).toBe(0); // 0 active sub-lists
+  });
+
+  it('marks isExplicit=true with the first byte', () => {
+    const enc = encodeTokenListOp({ isExplicit: true });
+    expect(enc.bytes[0]).toBe(1);
+  });
+
+  it('packs a single prepended sub-list with one item', () => {
+    const enc = encodeTokenListOp({ prepended: [7] });
+    // 2 (header) + 1 (listType) + 8 (numItems) + 4 (1 × uint32) = 15
+    expect(enc.bytes.length).toBe(15);
+    expect(enc.bytes[0]).toBe(0); // isExplicit
+    expect(enc.bytes[1]).toBe(1); // numActiveLists
+    expect(enc.bytes[2]).toBe(SdfListOpSubListType.Prepended);
+    const view = new DataView(enc.bytes.buffer, enc.bytes.byteOffset, enc.bytes.byteLength);
+    expect(view.getBigUint64(3, true)).toBe(1n);
+    expect(view.getUint32(11, true)).toBe(7);
+  });
+
+  it('packs multiple sub-lists in fixed canonical order', () => {
+    // Encoder walks explicit → added → deleted → ordered → prepended → appended.
+    const enc = encodeTokenListOp({
+      explicit: [10],
+      prepended: [20, 21],
+      appended: [30],
+    });
+    // Verify the sub-list type bytes appear in declaration order.
+    let dp = 2;
+    expect(enc.bytes[dp]).toBe(SdfListOpSubListType.Explicit); dp += 1 + 8 + 4 * 1;
+    expect(enc.bytes[dp]).toBe(SdfListOpSubListType.Prepended); dp += 1 + 8 + 4 * 2;
+    expect(enc.bytes[dp]).toBe(SdfListOpSubListType.Appended);
+  });
+
+  it('drops empty sub-lists from the output', () => {
+    const enc = encodeTokenListOp({
+      explicit: [],
+      prepended: [1, 2],
+      appended: [],
+    });
+    // Only `prepended` is non-empty.
+    expect(enc.bytes[1]).toBe(1);
+  });
+
+  it('rejects out-of-range tokenIndex values', () => {
+    expect(() => encodeTokenListOp({ prepended: [-1] })).toThrow(RangeError);
+    expect(() => encodeTokenListOp({ prepended: [0x100000000] })).toThrow(RangeError);
+    expect(() => encodeTokenListOp({ prepended: [1.5] })).toThrow(RangeError);
+  });
+});
+
+describe('encodeTokenListOp / decodeTokenListOp round-trip', () => {
+  it('round-trips an empty op', () => {
+    expect(roundTrip({})).toEqual({ isExplicit: false });
+  });
+
+  it('round-trips an isExplicit-only op', () => {
+    expect(roundTrip({ isExplicit: true })).toEqual({ isExplicit: true });
+  });
+
+  it('round-trips the prepend apiSchemas shape', () => {
+    const r = roundTrip({ prepended: [42] });
+    expect(r.prepended).toEqual([42]);
+    expect(r.isExplicit).toBe(false);
+  });
+
+  it('round-trips a multi-sublist op', () => {
+    const r = roundTrip({
+      explicit: [1, 2],
+      prepended: [3, 4, 5],
+      appended: [6],
+      deleted: [99],
+    });
+    expect(r.explicit).toEqual([1, 2]);
+    expect(r.prepended).toEqual([3, 4, 5]);
+    expect(r.appended).toEqual([6]);
+    expect(r.deleted).toEqual([99]);
+    expect(r.added).toBeUndefined();
+    expect(r.ordered).toBeUndefined();
+  });
+});
+
+describe('listOpValueRep', () => {
+  it('builds a non-array, non-inlined ValueRep with the encoded type', () => {
+    const enc = encodeTokenListOp({ prepended: [7] });
+    const rep = listOpValueRep(enc, 1024);
+    const fields = decodeValueRep(rep);
+    expect(fields.type).toBe(CrateDataType.TokenListOp);
+    expect(fields.isArray).toBe(false);
+    expect(fields.isInlined).toBe(false);
+    expect(fields.payload).toBe(1024n);
+  });
+});
+
+describe('decodeTokenListOp — error paths', () => {
+  it('throws on truncated header', () => {
+    expect(() => decodeTokenListOp(new Uint8Array(1))).toThrow();
+  });
+
+  it('throws when sub-list header is missing', () => {
+    // numActiveLists=1 but no sub-list bytes follow.
+    const buf = new Uint8Array([0, 1]);
+    expect(() => decodeTokenListOp(buf)).toThrow();
+  });
+
+  it('throws when item payload is short', () => {
+    // Claims 1 item but only 2 bytes of payload follow.
+    const buf = new Uint8Array([0, 1, SdfListOpSubListType.Prepended, 1, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff]);
+    expect(() => decodeTokenListOp(buf)).toThrow();
+  });
+});

--- a/src/__tests__/usdc-property-parser.test.ts
+++ b/src/__tests__/usdc-property-parser.test.ts
@@ -124,17 +124,33 @@ describe('parsePropertyKey — array attributes', () => {
   });
 });
 
-describe('parsePropertyKey — non-attribute keys (unsupported)', () => {
-  it('returns unsupported for prepend metadata', () => {
+describe('parsePropertyKey — list-op metadata', () => {
+  it('parses prepend xxx as a prepended list-op', () => {
     const r = parsePropertyKey('prepend apiSchemas');
-    expect(r.kind).toBe('unsupported');
+    expect(r).toEqual({ kind: 'list-op', name: 'apiSchemas', opcode: 'prepended' });
   });
 
-  it('returns unsupported for prepend references', () => {
+  it('parses append xxx as an appended list-op', () => {
+    const r = parsePropertyKey('append apiSchemas');
+    expect(r).toEqual({ kind: 'list-op', name: 'apiSchemas', opcode: 'appended' });
+  });
+
+  it('parses prepend references as a list-op key', () => {
     const r = parsePropertyKey('prepend references');
-    expect(r.kind).toBe('unsupported');
+    expect(r).toEqual({ kind: 'list-op', name: 'references', opcode: 'prepended' });
   });
 
+  it('parses delete xxx as a deleted list-op', () => {
+    const r = parsePropertyKey('delete apiSchemas');
+    expect(r).toEqual({ kind: 'list-op', name: 'apiSchemas', opcode: 'deleted' });
+  });
+
+  it('returns unsupported when the list-op key is missing a name', () => {
+    expect(parsePropertyKey('prepend ').kind).toBe('unsupported');
+  });
+});
+
+describe('parsePropertyKey — non-attribute keys (unsupported)', () => {
   it('returns unsupported for connection (.connect suffix)', () => {
     const r = parsePropertyKey('token outputs:surface.connect');
     expect(r.kind).toBe('unsupported');

--- a/src/__tests__/usdc-usd-node-adapter.test.ts
+++ b/src/__tests__/usdc-usd-node-adapter.test.ts
@@ -113,12 +113,37 @@ describe('applyProperty — scalar dispatch', () => {
     expect(r.emitted).toBe(true);
   });
 
-  it('skips connection / relationship / list-op keys', () => {
+  it('skips connection and relationship keys', () => {
     const b = new UsdcLayerBuilder();
     const root = b.declarePrim('/Root', 'Material');
     expect(applyProperty(b, root, 'token outputs:surface.connect', '<x>').emitted).toBe(false);
     expect(applyProperty(b, root, 'material:binding', '<x>').emitted).toBe(false);
-    expect(applyProperty(b, root, 'prepend apiSchemas', ['x']).emitted).toBe(false);
+  });
+
+  it('emits a TokenListOp for prepend apiSchemas', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Xform');
+    const r = applyProperty(b, root, 'prepend apiSchemas', ['MaterialBindingAPI']);
+    expect(r.emitted).toBe(true);
+  });
+
+  it('emits a TokenListOp for append apiSchemas', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Xform');
+    const r = applyProperty(b, root, 'append apiSchemas', ['MaterialBindingAPI', 'Other']);
+    expect(r.emitted).toBe(true);
+  });
+
+  it('skips list-ops for fields that are not TokenListOp-shaped (e.g. references)', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Xform');
+    expect(applyProperty(b, root, 'prepend references', ['@asset.usd@']).emitted).toBe(false);
+  });
+
+  it('skips list-ops whose value is not a string array', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Xform');
+    expect(applyProperty(b, root, 'prepend apiSchemas', 'not-an-array').emitted).toBe(false);
   });
 });
 
@@ -274,7 +299,7 @@ describe('adaptUsdNodeTree — properties report', () => {
     const root = new UsdNode('/Root', 'Xform');
     root.setProperty('uniform token[] xformOpOrder', ['xformOp:translate']);
     root.setProperty('material:binding', '<x>');
-    root.setProperty('prepend apiSchemas', ['MaterialBindingAPI']);
+    root.setProperty('token outputs:surface.connect', '<x>');
 
     const builder = new UsdcLayerBuilder();
     const report = adaptUsdNodeTree(root, builder);
@@ -282,5 +307,16 @@ describe('adaptUsdNodeTree — properties report', () => {
     const unsupported = report.properties.filter((p) => !p.emitted);
     expect(unsupported.length).toBe(2);
     for (const u of unsupported) expect(u.reason).toBeDefined();
+  });
+
+  it('emits TokenListOp for prepend apiSchemas during a tree walk', () => {
+    const root = new UsdNode('/Root', 'Xform');
+    root.setProperty('prepend apiSchemas', ['MaterialBindingAPI']);
+
+    const builder = new UsdcLayerBuilder();
+    const report = adaptUsdNodeTree(root, builder);
+    expect(report.skipped).toBe(0);
+    const apiSchemasReport = report.properties.find((p) => p.rawKey === 'prepend apiSchemas');
+    expect(apiSchemasReport?.emitted).toBe(true);
   });
 });

--- a/src/converters/shared/usdc/layer-builder.ts
+++ b/src/converters/shared/usdc/layer-builder.ts
@@ -53,6 +53,7 @@ import {
   encodeTokenArray,
   arrayValueRep,
 } from './array-values';
+import { encodeTokenListOp, type TokenListOpInput } from './listop-values';
 import {
   CrateDataType,
   SdfSpecType,
@@ -294,6 +295,50 @@ export class UsdcLayerBuilder {
   addTokenArrayAttribute(prim: PrimHandle, name: string, tokenValues: ReadonlyArray<string>): void {
     const indices = tokenValues.map((t) => this.tokens.intern(t));
     const enc = encodeTokenArray(indices);
+    const arrayId = this.pendingArrays.length;
+    this.pendingArrays.push({ encoded: enc });
+    const fieldTok = this.tokens.intern(name);
+    this.specBuilders[prim.pathIndex].fields.push({
+      tokenIndex: fieldTok,
+      rep: { kind: 'array', arrayId },
+    });
+  }
+
+  /**
+   * Add a TokenListOp metadata attribute. The most common shape is a
+   * single `prepended` list (e.g. `prepend apiSchemas = ["MaterialBindingAPI"]`).
+   * Pass token *strings*; the builder interns them.
+   *
+   * The `name` must include the opcode prefix the adapter expects to round-
+   * trip back through the property parser (e.g. `apiSchemas` — *not*
+   * `prepend apiSchemas`); the opcode is captured in which sub-list the
+   * caller fills.
+   */
+  addTokenListOpAttribute(
+    prim: PrimHandle,
+    name: string,
+    op: {
+      isExplicit?: boolean;
+      explicit?: ReadonlyArray<string>;
+      added?: ReadonlyArray<string>;
+      deleted?: ReadonlyArray<string>;
+      ordered?: ReadonlyArray<string>;
+      prepended?: ReadonlyArray<string>;
+      appended?: ReadonlyArray<string>;
+    }
+  ): void {
+    const internAll = (xs: ReadonlyArray<string> | undefined) =>
+      xs ? xs.map((t) => this.tokens.intern(t)) : undefined;
+    const input: TokenListOpInput = {
+      ...(op.isExplicit !== undefined ? { isExplicit: op.isExplicit } : {}),
+      ...(op.explicit ? { explicit: internAll(op.explicit)! } : {}),
+      ...(op.added ? { added: internAll(op.added)! } : {}),
+      ...(op.deleted ? { deleted: internAll(op.deleted)! } : {}),
+      ...(op.ordered ? { ordered: internAll(op.ordered)! } : {}),
+      ...(op.prepended ? { prepended: internAll(op.prepended)! } : {}),
+      ...(op.appended ? { appended: internAll(op.appended)! } : {}),
+    };
+    const enc = encodeTokenListOp(input);
     const arrayId = this.pendingArrays.length;
     this.pendingArrays.push({ encoded: enc });
     const fieldTok = this.tokens.intern(name);

--- a/src/converters/shared/usdc/listop-values.ts
+++ b/src/converters/shared/usdc/listop-values.ts
@@ -1,0 +1,193 @@
+/** WebUsdFramework.Converters.Shared.Usdc.ListOpValues — encoder for the
+ *  list-op value types used by `prepend apiSchemas` / `append apiSchemas` /
+ *  `prepend references` and friends.
+ *
+ * A `SdfListOp<T>` carries up to six independent sub-lists:
+ *
+ *   - explicit  — overrides any inherited list (rare; replaces the whole list)
+ *   - added     — legacy; modern USD avoids this in favor of prepend/append
+ *   - prepended — items pushed onto the front of the inherited list
+ *   - appended  — items pushed onto the end of the inherited list
+ *   - deleted   — items removed from the inherited list
+ *   - ordered   — items present in a particular order
+ *
+ * The most common shape in our converters is a single `prepended` sub-list
+ * with one or two TokenIndex values (e.g. `prepend apiSchemas =
+ * ["MaterialBindingAPI"]`).
+ *
+ * On-disk wire format (uncompressed):
+ *
+ *   uint8                  isExplicit         (1 = the explicit sub-list is set)
+ *   uint8                  numActiveLists     (count of non-empty sub-lists)
+ *   for each active list:
+ *     uint8                listType           (0..5; see SdfListOpSubListType)
+ *     uint64               numItems
+ *     uint32[numItems]     TokenIndex per item
+ *
+ * Reference: `pxr/usd/sdf/listOp.cpp` and `pxr/usd/usd/crateFile.cpp`
+ * (search for `_WriteListOp`).
+ */
+
+import { CrateDataType, externalValueRep } from './value-rep';
+import type { EncodedArrayValue } from './array-values';
+
+/** Sub-list opcode encoding — fixed by the wire format. */
+export const SdfListOpSubListType = {
+  Explicit: 0,
+  Added: 1,
+  Deleted: 2,
+  Ordered: 3,
+  Prepended: 4,
+  Appended: 5,
+} as const;
+export type SdfListOpSubListType =
+  (typeof SdfListOpSubListType)[keyof typeof SdfListOpSubListType];
+
+/** Mutable description of a TokenListOp before serialization. */
+export interface TokenListOpInput {
+  isExplicit?: boolean;
+  explicit?: ReadonlyArray<number>;
+  added?: ReadonlyArray<number>;
+  deleted?: ReadonlyArray<number>;
+  ordered?: ReadonlyArray<number>;
+  prepended?: ReadonlyArray<number>;
+  appended?: ReadonlyArray<number>;
+}
+
+function validateTokenIndices(label: string, items: ReadonlyArray<number>): void {
+  for (let i = 0; i < items.length; i++) {
+    const v = items[i];
+    if (!Number.isInteger(v) || v < 0 || v > 0xffffffff) {
+      throw new RangeError(
+        `encodeTokenListOp: ${label}[${i}] = ${v} is out of uint32 range`
+      );
+    }
+  }
+}
+
+/**
+ * Encode a TokenListOp as the bytes that go at a file offset, plus the
+ * `EncodedArrayValue` envelope the layer-builder wants. The resulting
+ * ValueRep has `type: TokenListOp`, `isArray: false`, `isCompressed: false`.
+ */
+export function encodeTokenListOp(input: TokenListOpInput): EncodedArrayValue {
+  const sublists: { type: SdfListOpSubListType; items: ReadonlyArray<number> }[] = [];
+  if (input.explicit && input.explicit.length > 0) {
+    validateTokenIndices('explicit', input.explicit);
+    sublists.push({ type: SdfListOpSubListType.Explicit, items: input.explicit });
+  }
+  if (input.added && input.added.length > 0) {
+    validateTokenIndices('added', input.added);
+    sublists.push({ type: SdfListOpSubListType.Added, items: input.added });
+  }
+  if (input.deleted && input.deleted.length > 0) {
+    validateTokenIndices('deleted', input.deleted);
+    sublists.push({ type: SdfListOpSubListType.Deleted, items: input.deleted });
+  }
+  if (input.ordered && input.ordered.length > 0) {
+    validateTokenIndices('ordered', input.ordered);
+    sublists.push({ type: SdfListOpSubListType.Ordered, items: input.ordered });
+  }
+  if (input.prepended && input.prepended.length > 0) {
+    validateTokenIndices('prepended', input.prepended);
+    sublists.push({ type: SdfListOpSubListType.Prepended, items: input.prepended });
+  }
+  if (input.appended && input.appended.length > 0) {
+    validateTokenIndices('appended', input.appended);
+    sublists.push({ type: SdfListOpSubListType.Appended, items: input.appended });
+  }
+
+  // Compute total size: 1 (isExplicit) + 1 (numActiveLists) +
+  //   per-list: 1 (type) + 8 (numItems) + 4 × items.length
+  let total = 2;
+  for (const s of sublists) total += 1 + 8 + 4 * s.items.length;
+
+  const bytes = new Uint8Array(total);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let dp = 0;
+
+  bytes[dp++] = input.isExplicit ? 1 : 0;
+  bytes[dp++] = sublists.length;
+
+  for (const s of sublists) {
+    bytes[dp++] = s.type;
+    view.setBigUint64(dp, BigInt(s.items.length), /* littleEndian */ true);
+    dp += 8;
+    for (let i = 0; i < s.items.length; i++) {
+      view.setUint32(dp, s.items[i], true);
+      dp += 4;
+    }
+  }
+
+  return {
+    bytes,
+    type: CrateDataType.TokenListOp,
+    isCompressed: false,
+    count: sublists.length, // metadata only; not used by anyone today
+    isArray: false,
+  };
+}
+
+/**
+ * Decode a TokenListOp value from raw bytes. Used by tests; not on the
+ * runtime encoding path.
+ */
+export function decodeTokenListOp(src: Uint8Array): TokenListOpInput {
+  if (src.length < 2) throw new RangeError('decodeTokenListOp: header truncated');
+  const view = new DataView(src.buffer, src.byteOffset, src.byteLength);
+  let sp = 0;
+  const isExplicit = src[sp++] === 1;
+  const numLists = src[sp++];
+  const out: TokenListOpInput = { isExplicit };
+  for (let l = 0; l < numLists; l++) {
+    if (sp + 9 > src.length) throw new RangeError('decodeTokenListOp: sub-list header truncated');
+    const listType = src[sp++] as SdfListOpSubListType;
+    const numItems = Number(view.getBigUint64(sp, true));
+    sp += 8;
+    if (sp + 4 * numItems > src.length) {
+      throw new RangeError('decodeTokenListOp: item payload truncated');
+    }
+    const items: number[] = new Array(numItems);
+    for (let i = 0; i < numItems; i++) {
+      items[i] = view.getUint32(sp, true);
+      sp += 4;
+    }
+    switch (listType) {
+      case SdfListOpSubListType.Explicit:
+        out.explicit = items;
+        break;
+      case SdfListOpSubListType.Added:
+        out.added = items;
+        break;
+      case SdfListOpSubListType.Deleted:
+        out.deleted = items;
+        break;
+      case SdfListOpSubListType.Ordered:
+        out.ordered = items;
+        break;
+      case SdfListOpSubListType.Prepended:
+        out.prepended = items;
+        break;
+      case SdfListOpSubListType.Appended:
+        out.appended = items;
+        break;
+      default:
+        throw new RangeError(`decodeTokenListOp: unknown sublist type ${listType}`);
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the ValueRep for an encoded ListOp once its file offset is known.
+ * Same semantics as `arrayValueRep`, but the type bit always encodes as a
+ * scalar (`isArray: false`) since list-ops are themselves their own type.
+ */
+export function listOpValueRep(value: EncodedArrayValue, fileOffset: number | bigint): bigint {
+  return externalValueRep({
+    type: value.type,
+    isArray: false,
+    isCompressed: value.isCompressed,
+    fileOffset,
+  });
+}

--- a/src/converters/shared/usdc/property-parser.ts
+++ b/src/converters/shared/usdc/property-parser.ts
@@ -25,6 +25,9 @@
 
 import { CrateDataType } from './value-rep';
 
+/** Sub-list opcode parsed from a USDA `prepend|append|add|delete|reorder` key. */
+export type ListOpOpcode = 'prepended' | 'appended' | 'added' | 'deleted' | 'ordered';
+
 /** Type-tagged result — what the encoder needs to do with this property. */
 export type ParsedProperty =
   | {
@@ -35,11 +38,27 @@ export type ParsedProperty =
     isUniform: boolean;
   }
   | {
+    /** A `prepend|append|...` list-op metadata key. The element type is
+     * implied by `name` — the adapter dispatches per-name (e.g. `apiSchemas`
+     * is a TokenListOp). */
+    kind: 'list-op';
+    name: string;
+    opcode: ListOpOpcode;
+  }
+  | {
     kind: 'unsupported';
     /** The original key, kept verbatim so the caller can log / route it. */
     raw: string;
     reason: string;
   };
+
+const LIST_OP_PREFIXES: Record<string, ListOpOpcode> = {
+  prepend: 'prepended',
+  append: 'appended',
+  add: 'added',
+  delete: 'deleted',
+  reorder: 'ordered',
+};
 
 /** Map from a single USD type token to the corresponding CrateDataType. */
 const TYPE_MAP: Record<string, { type: CrateDataType; isArray: boolean }> = {
@@ -92,13 +111,19 @@ export function parsePropertyKey(rawKey: string): ParsedProperty {
     return { kind: 'unsupported', raw: rawKey, reason: 'empty key' };
   }
 
-  // Reject metadata-style keys outright — these don't fit the attribute grammar.
-  if (key.startsWith('prepend ') || key.startsWith('append ')) {
-    return {
-      kind: 'unsupported',
-      raw: rawKey,
-      reason: `list-op metadata (\"${key.split(' ')[0]}\") is not yet supported`,
-    };
+  // List-op metadata keys (`prepend xxx`, `append xxx`, ...).
+  for (const [prefix, opcode] of Object.entries(LIST_OP_PREFIXES)) {
+    if (key.startsWith(prefix + ' ')) {
+      const name = key.slice(prefix.length + 1).trim();
+      if (name.length === 0) {
+        return {
+          kind: 'unsupported',
+          raw: rawKey,
+          reason: `list-op key \"${prefix}\" missing field name`,
+        };
+      }
+      return { kind: 'list-op', name, opcode };
+    }
   }
   if (key.endsWith('.connect')) {
     return { kind: 'unsupported', raw: rawKey, reason: 'attribute connection' };

--- a/src/converters/shared/usdc/usd-node-adapter.ts
+++ b/src/converters/shared/usdc/usd-node-adapter.ts
@@ -16,7 +16,11 @@
 
 import { UsdNode } from '../../../core/usd-node';
 import { UsdcLayerBuilder, type PrimHandle } from './layer-builder';
-import { parsePropertyKey, type ParsedProperty } from './property-parser';
+import {
+  parsePropertyKey,
+  type ParsedProperty,
+  type ListOpOpcode,
+} from './property-parser';
 import { CrateDataType } from './value-rep';
 import { parseVec3fScalar, parseVec3fArray } from './usda-value-parser';
 
@@ -86,6 +90,9 @@ export function applyProperty(
   const parsed = parsePropertyKey(key);
   if (parsed.kind === 'unsupported') {
     return { rawKey: key, emitted: false, reason: parsed.reason };
+  }
+  if (parsed.kind === 'list-op') {
+    return applyListOp(builder, prim, parsed.name, parsed.opcode, value, key);
   }
   return applyTypedAttribute(builder, prim, parsed, value, key);
 }
@@ -259,6 +266,44 @@ function coerceStringArray(value: unknown): string[] | null {
 
 function skipped(rawKey: string, reason: string): AdaptedProperty {
   return { rawKey, emitted: false, reason };
+}
+
+/**
+ * The set of list-op field names whose elements are tokens (TokenListOp).
+ * Other element types (PathListOp for `references`, ReferenceListOp, etc.)
+ * are not yet wired up — those are routed to `unsupported` until their
+ * value encoders land.
+ */
+const TOKEN_LIST_OP_NAMES = new Set([
+  'apiSchemas',
+]);
+
+/**
+ * Dispatch a list-op key (`prepend apiSchemas`, `append xxx`, ...) to the
+ * appropriate layer-builder method.
+ *
+ * The element type is inferred from the field name. We currently only emit
+ * TokenListOp values (the only list-op shape our converters produce). Other
+ * shapes (PathListOp / ReferenceListOp / etc.) fall into the unsupported
+ * bucket so the packager can fall back to USDA cleanly.
+ */
+function applyListOp(
+  builder: UsdcLayerBuilder,
+  prim: PrimHandle,
+  name: string,
+  opcode: ListOpOpcode,
+  value: unknown,
+  rawKey: string
+): AdaptedProperty {
+  if (!TOKEN_LIST_OP_NAMES.has(name)) {
+    return skipped(rawKey, `list-op for "${name}" is not yet a TokenListOp shape`);
+  }
+  const tokens = coerceStringArray(value);
+  if (!tokens) {
+    return skipped(rawKey, `${opcode} ${name}: expected an array of token strings`);
+  }
+  builder.addTokenListOpAttribute(prim, name, { [opcode]: tokens });
+  return { rawKey, emitted: true };
 }
 
 /** Find the CrateDataType name corresponding to a numeric value, for error messages. */


### PR DESCRIPTION
## Summary

Adds the TokenListOp value type to the USDC encoder and wires it through
the property-parser, layer-builder, and UsdNode adapter. After this
lands, `prepend apiSchemas = ["MaterialBindingAPI"]` (the most common
list-op shape our converters emit) no longer forces a USDA fallback.

This is one of the three blockers for letting `convertPlyToUsdz` actually
emit binary `model.usdc` for a real PLY scene; the remaining two are the
Relationship spec (for `material:binding`) and the Connection spec (for
`outputs:surface.connect`).

## What lands here (2 focused commits)

1. **TokenListOp value encoder** — pure value-encoding addition; no
   changes to PATHS / SPECS / FIELDSETS. 14 round-trip + layout +
   error tests.
2. **Wire-up** — property-parser now returns `kind: 'list-op'` for all
   five USDA list-op prefixes (`prepend|append|add|delete|reorder`).
   Layer-builder gains `addTokenListOpAttribute`. Adapter dispatches
   list-op keys to it for the field names whose elements are tokens
   (just `apiSchemas` today). 9 new tests.

## What does NOT land here

- **PathListOp / ReferenceListOp**: needed for `prepend references`,
  `prepend payloads`. Same wire-format family but elements are paths,
  not tokens — needs PathVector / Reference value encoders first.
- **Relationship spec** (for `material:binding`): adds a new
  `SdfSpecType.Relationship` branch in the layer builder, plus a path
  entry under the parent prim and a `targetPaths` field as a
  PathListOp value.
- **Connection spec** (for `outputs:surface.connect`): adds a new
  `SdfSpecType.Connection` branch and a connection-target value.

Once those three land, PLY's `layerFormat: 'usdc'` flips from "falls
back to USDA" to "actually emits binary," and `usdcat` byte-level
validation becomes the only remaining gate before flipping the
default.

## Test plan

- [x] All 322 tests pass (`pnpm run test:run`)
- [x] Type-check clean (`pnpm run type-check`)
- [x] 23 new tests (14 ListOp value encoder + 5 parser + 4 adapter)
- [ ] Follow-up: PathListOp / ReferenceListOp value encoders
- [ ] Follow-up: Relationship spec + path entry
- [ ] Follow-up: Connection spec
- [ ] Follow-up: PLY end-to-end test that asserts `model.usdc` is the
      first archive entry once all three above land

Refs #122