### PR TITLE
feat(usdc): Relationship spec for material:binding

### DIFF
--- a/hashes.md/.chronos.json
+++ b/hashes.md/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Root",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-22 - 2025-11-27",
+        "changes": ["Initial framework", "GLTF converter", "OBJ converter", "STL converter", "FBX converter", "USDC binary encoder", "Forensic integrity system"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/.contract.json
+++ b/hashes.md/.contract.json
@@ -1,0 +1,30 @@
+{
+  "ForensicShard": "WebUsdFramework.Root",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "defineConfig": {
+      "input": "FrameworkOptions",
+      "output": "FrameworkInstance",
+      "guarantees": ["type-safe", "immutable-config"],
+      "dependencies": ["@root/hashes.md/schemas/index.hash.md"]
+    },
+    "convert": {
+      "input": "string (inputPath)",
+      "output": "Promise<Blob> (USDZ binary)",
+      "guarantees": ["streaming-capable", "memory-bounded"],
+      "dependencies": ["@root/hashes.md/converters/gltf/index.hash.md", "@root/hashes.md/converters/ply/ply-converter.hash.md", "@root/hashes.md/converters/obj/index.hash.md", "@root/hashes.md/converters/stl/index.hash.md"]
+    }
+  },
+  "Interfaces": {
+    "IConverter": {
+      "methods": ["convert(input: string, options: IConverterOptions): Promise<IConversionResult>"],
+      "implementors": ["GltfConverter", "ObjConverter", "StlConverter", "PlyConverter"]
+    },
+    "IConverterOptions": {
+      "fields": ["debug", "debugOutputDir", "upAxis", "metersPerUnit"]
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/.logic.md
+++ b/hashes.md/.logic.md
@@ -1,0 +1,66 @@
+# WebUsdFramework - Root Business Logic
+
+> **The Hash is the Truth. The Grammar is the Law. The History is the Evidence.**
+
+## Forensic Sharding Architecture
+
+### O(1) Search Efficiency
+This document decouples metadata into shardable files ensuring constant-time lookups:
+- `.contract.json` → API surface and type contracts
+- `.logic.md` → Business rules and governance laws
+- `.chronos.json` → Temporal evolution and mutation history
+
+## Core Business Rules
+
+### 1. Conversion Pipeline Law
+```
+Input → Parse → Transform → Serialize → Package
+  ↓       ↓         ↓           ↓          ↓
+GLB   GLTF    USD Node    USDA/USDC   USDZ
+PLY   PLY     USD Node    USDA/USDC   USDZ
+OBJ   OBJ     USD Node    USDA/USDC   USDZ
+STL   STL     USD Node    USDA/USDC   USDZ
+```
+
+### 2. Node Graph Invariant
+- All geometry MUST pass through `UsdNode` abstraction
+- No raw string building in converters (violation: Governance_Law)
+- Hierarchical parent-child relationships enforced at type level
+
+### 3. Memory Governance
+- Streaming for files > 10MB
+- Large TypedArrays use chunked serialization
+- Debug mode writes intermediate files (never in production)
+
+### 4. Type Safety Laws
+- `FrameworkError` subclasses ONLY (no raw Error leaks)
+- All inputs validated through `validation.ts`
+- Options normalized before entering converter pipeline
+
+### 5. Module Boundary Laws
+```
+Constants → Pure values, no deps
+Utils → No converter deps, reusable everywhere
+Core → Depends only on utils/constants
+Converters → Depend on core + utils + shared
+Shared → Bridge between core and converters
+Schemas → Template strings, no runtime logic
+CLI → Depends on everything, entry point
+```
+
+## Error Propagation Topology
+```
+ValidationError (input validation)
+  ↓
+ConversionError (converter failures)
+  ↓
+FrameworkError (base class)
+  ↓
+UnsupportedFormatError (format not supported)
+```
+
+## USDZ Packaging Rules
+1. USDA/USDC files must be 64-byte aligned
+2. Assets (textures, payloads) follow ZIP64 spec
+3. All paths use forward slashes internally
+4. MIME types inferred from file extensions

--- a/hashes.md/__tests__/.chronos.json
+++ b/hashes.md/__tests__/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Tests",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-22 - 2026-04-27",
+        "changes": ["Converter tests", "USD node tests", "USDC section tests", "Streaming tests", "End-to-end tests"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/__tests__/.contract.json
+++ b/hashes.md/__tests__/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Tests",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "Test suite",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/__tests__/.logic.md
+++ b/hashes.md/__tests__/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Tests - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+Test suite

--- a/hashes.md/__tests__/converter-streaming.test.hash.md
+++ b/hashes.md/__tests__/converter-streaming.test.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.ConverterStreaming.test
+
+/** WebUsdFramework.__tests__.ConverterStreaming.test - Per-converter byte-equivalence tests for the streaming output path. */
+
+### [Signatures]
+- `makeMinimalPly()`
+- `makeMinimalObj()`
+- `makeMinimalStl()`
+- `blobToBytes()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/converters.test.hash.md
+++ b/hashes.md/__tests__/converters.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.Converters.test
+
+/** WebUsdFramework.__tests__.Converters.test - GLB→USDZ converter integration tests */
+
+### [Signatures]
+- `extractUsda()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/ply-converter.test.hash.md
+++ b/hashes.md/__tests__/ply-converter.test.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.PlyConverter.test
+
+/** WebUsdFramework.__tests__.PlyConverter.test - Tests for PLY parser and converter */
+
+### [Signatures]
+- `toBuffer()`
+- `buildBinaryPly()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usd-node.test.hash.md
+++ b/hashes.md/__tests__/usd-node.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdNode.test
+
+/** WebUsdFramework.__tests__.UsdNode.test - UsdNode unit tests */
+
+### [Signatures]
+- `export` barrel re-exports
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usd-packaging-stream.test.hash.md
+++ b/hashes.md/__tests__/usd-packaging-stream.test.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdPackagingStream.test
+
+/** WebUsdFramework.__tests__.UsdPackagingStream.test - Byte-equivalence tests for the streaming USDZ packaging APIs. */
+
+### [Signatures]
+- `toBytes()`
+- `makeContent()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-array-values.test.hash.md
+++ b/hashes.md/__tests__/usdc-array-values.test.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcArrayValues.test
+
+/** WebUsdFramework.__tests__.UsdcArrayValues.test - Round-trip tests for the USDC array-value encoders (Float[], Vec3f[], */
+
+### [Signatures]
+- `readFloats()`
+- `readInts()`
+- `readUint32s()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-fields-section.test.hash.md
+++ b/hashes.md/__tests__/usdc-fields-section.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcFieldsSection.test
+
+/** WebUsdFramework.__tests__.UsdcFieldsSection.test - Round-trip tests for the USDC FIELDS section encoder. */
+
+### [Signatures]
+- `fieldsEqual()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-fieldsets-section.test.hash.md
+++ b/hashes.md/__tests__/usdc-fieldsets-section.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcFieldsetsSection.test
+
+/** WebUsdFramework.__tests__.UsdcFieldsetsSection.test - Tests for the USDC FIELDSETS section encoder + FieldSetTable builder. */
+
+### [Signatures]
+- `export` barrel re-exports
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-integer-coding.test.hash.md
+++ b/hashes.md/__tests__/usdc-integer-coding.test.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcIntegerCoding.test
+
+/** WebUsdFramework.__tests__.UsdcIntegerCoding.test - Round-trip tests for the TfDelta integer-coding utility. */
+
+### [Signatures]
+- `roundTripInt32()`
+- `roundTripInt64()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-layer-builder.test.hash.md
+++ b/hashes.md/__tests__/usdc-layer-builder.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcLayerBuilder.test
+
+/** WebUsdFramework.__tests__.UsdcLayerBuilder.test - Integration tests for the USDC layer builder. */
+
+### [Signatures]
+- `readToc()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-listop-values.test.hash.md
+++ b/hashes.md/__tests__/usdc-listop-values.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcListopValues.test
+
+/** WebUsdFramework.__tests__.UsdcListopValues.test - Tests for the TokenListOp value encoder. */
+
+### [Signatures]
+- `roundTrip()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-lz4-block.test.hash.md
+++ b/hashes.md/__tests__/usdc-lz4-block.test.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcLz4Block.test
+
+/** WebUsdFramework.__tests__.UsdcLz4Block.test - LZ4 block-format codec tests. */
+
+### [Signatures]
+- `utf8()`
+- `roundTrip()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-package-integration.test.hash.md
+++ b/hashes.md/__tests__/usdc-package-integration.test.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcPackageIntegration.test
+
+/** WebUsdFramework.__tests__.UsdcPackageIntegration.test - End-to-end tests for the layerFormat: 'usdc' option through the packaging */
+
+### [Signatures]
+- `readArchiveNames()`
+- `basicContent()`
+- `basicTree()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-paths-section.test.hash.md
+++ b/hashes.md/__tests__/usdc-paths-section.test.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcPathsSection.test
+
+/** WebUsdFramework.__tests__.UsdcPathsSection.test - Tests for the USDC PATHS section encoder. */
+
+### [Signatures]
+- `makeLeaf()`
+- `treesEqual()`
+- `roundTrip()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-ply-end-to-end.test.hash.md
+++ b/hashes.md/__tests__/usdc-ply-end-to-end.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcPlyEndToEnd.test
+
+/** WebUsdFramework.__tests__.UsdcPlyEndToEnd.test - End-to-end PLY → USDZ tests with `layerFormat: 'usdc'`. */
+
+### [Signatures]
+- `readArchiveNames()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-property-parser.test.hash.md
+++ b/hashes.md/__tests__/usdc-property-parser.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcPropertyParser.test
+
+/** WebUsdFramework.__tests__.UsdcPropertyParser.test - Tests for the UsdNode property-key parser. */
+
+### [Signatures]
+- `export` barrel re-exports
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-specs-section.test.hash.md
+++ b/hashes.md/__tests__/usdc-specs-section.test.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcSpecsSection.test
+
+/** WebUsdFramework.__tests__.UsdcSpecsSection.test - Round-trip tests for the USDC SPECS section encoder. */
+
+### [Signatures]
+- `specsEqual()`
+- `roundTrip()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-strings-section.test.hash.md
+++ b/hashes.md/__tests__/usdc-strings-section.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcStringsSection.test
+
+/** WebUsdFramework.__tests__.UsdcStringsSection.test - Tests for the USDC STRINGS section encoder + StringTable. */
+
+### [Signatures]
+- `roundTrip()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-tokens-section.test.hash.md
+++ b/hashes.md/__tests__/usdc-tokens-section.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcTokensSection.test
+
+/** WebUsdFramework.__tests__.UsdcTokensSection.test - Tests for the USDC TOKENS section encoder + interning table. */
+
+### [Signatures]
+- `roundTrip()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-usd-node-adapter.test.hash.md
+++ b/hashes.md/__tests__/usdc-usd-node-adapter.test.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcUsdNodeAdapter.test
+
+/** WebUsdFramework.__tests__.UsdcUsdNodeAdapter.test - Tests for the UsdNode → UsdcLayerBuilder adapter. */
+
+### [Signatures]
+- `readToc()`
+- `getTokens()`
+- `makeScene()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-usda-value-parser.test.hash.md
+++ b/hashes.md/__tests__/usdc-usda-value-parser.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcUsdaValueParser.test
+
+/** WebUsdFramework.__tests__.UsdcUsdaValueParser.test - Tests for the USDA literal parser used by the UsdNode → USDC adapter. */
+
+### [Signatures]
+- `export` barrel re-exports
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-value-rep.test.hash.md
+++ b/hashes.md/__tests__/usdc-value-rep.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcValueRep.test
+
+/** WebUsdFramework.__tests__.UsdcValueRep.test - Tests for the USDC ValueRep packer + inlined-value helpers. */
+
+### [Signatures]
+- `export` barrel re-exports
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdc-writer.test.hash.md
+++ b/hashes.md/__tests__/usdc-writer.test.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdcWriter.test
+
+/** WebUsdFramework.__tests__.UsdcWriter.test - Byte-level unit tests for the USDC (Crate) writer scaffold. */
+
+### [Signatures]
+- `export` barrel re-exports
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/__tests__/usdz-stream-writer.test.hash.md
+++ b/hashes.md/__tests__/usdz-stream-writer.test.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.__tests__.UsdzStreamWriter.test
+
+/** WebUsdFramework.__tests__.UsdzStreamWriter.test - Byte-equivalence tests for the streaming USDZ writer. */
+
+### [Signatures]
+- `toBytes()`
+- `bufferedWrite()`
+- `streamingWrite()`
+- `utf8()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/__tests__/.contract.json"
+- logic: "@root/hashes.md/__tests__/.logic.md"
+- chronos: "@root/hashes.md/__tests__/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/cli/.chronos.json
+++ b/hashes.md/cli/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Cli",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2026-04-18T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2026-04-18 - 2026-04-18",
+        "changes": ["CLI structure", "Effect TS integration", "Converter service"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/cli/.contract.json
+++ b/hashes.md/cli/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Cli",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "Command-line interface",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/cli/.logic.md
+++ b/hashes.md/cli/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Cli - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+Command-line interface

--- a/hashes.md/cli/constants/.chronos.json
+++ b/hashes.md/cli/constants/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Cli.Constants",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2026-04-18T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2026-04-18 - 2026-04-18",
+        "changes": ["CLI constants"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/cli/constants/.contract.json
+++ b/hashes.md/cli/constants/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Cli.Constants",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "CLI constants",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/cli/constants/.logic.md
+++ b/hashes.md/cli/constants/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Cli.Constants - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+CLI constants

--- a/hashes.md/cli/constants/constants.hash.md
+++ b/hashes.md/cli/constants/constants.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Cli.Constants.Constants
+
+/** WebUsdFramework.Cli.Constants.Constants - Cli.Constants.Constants module */
+
+### [Signatures]
+- `CLI_VERSION()`
+- `SUPPORTED_EXTENSIONS()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/cli/constants/.contract.json"
+- logic: "@root/hashes.md/cli/constants/.logic.md"
+- chronos: "@root/hashes.md/cli/constants/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/cli/constants/index.hash.md
+++ b/hashes.md/cli/constants/index.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Cli.Constants.Index
+
+/** WebUsdFramework.Cli.Constants.Index - Cli.Constants.Index module */
+
+### [Signatures]
+- `export` barrel re-exports
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/cli/constants/.contract.json"
+- logic: "@root/hashes.md/cli/constants/.logic.md"
+- chronos: "@root/hashes.md/cli/constants/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/cli/errors/.chronos.json
+++ b/hashes.md/cli/errors/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Cli.Errors",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2026-04-18T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2026-04-18 - 2026-04-18",
+        "changes": ["CLI error types"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/cli/errors/.contract.json
+++ b/hashes.md/cli/errors/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Cli.Errors",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "CLI error handling",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/cli/errors/.logic.md
+++ b/hashes.md/cli/errors/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Cli.Errors - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+CLI error handling

--- a/hashes.md/cli/errors/errors.hash.md
+++ b/hashes.md/cli/errors/errors.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Cli.Errors.Errors
+
+/** WebUsdFramework.Cli.Errors.Errors - Cli.Errors.Errors module */
+
+### [Signatures]
+- `CliConfigError()`
+- `ConversionError()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/cli/errors/.contract.json"
+- logic: "@root/hashes.md/cli/errors/.logic.md"
+- chronos: "@root/hashes.md/cli/errors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/cli/errors/index.hash.md
+++ b/hashes.md/cli/errors/index.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Cli.Errors.Index
+
+/** WebUsdFramework.Cli.Errors.Index - Cli.Errors.Index module */
+
+### [Signatures]
+- `export` barrel re-exports
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/cli/errors/.contract.json"
+- logic: "@root/hashes.md/cli/errors/.logic.md"
+- chronos: "@root/hashes.md/cli/errors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/cli/index.hash.md
+++ b/hashes.md/cli/index.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Cli.Index
+
+/** WebUsdFramework.Cli.Index - Cli.Index module */
+
+### [Signatures]
+- `export` barrel re-exports
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/cli/.contract.json"
+- logic: "@root/hashes.md/cli/.logic.md"
+- chronos: "@root/hashes.md/cli/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/cli/main.hash.md
+++ b/hashes.md/cli/main.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Cli.Main
+
+/** WebUsdFramework.Cli.Main - Cli.Main module */
+
+### [Signatures]
+- `export` barrel re-exports
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/cli/.contract.json"
+- logic: "@root/hashes.md/cli/.logic.md"
+- chronos: "@root/hashes.md/cli/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/cli/services/.chronos.json
+++ b/hashes.md/cli/services/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Cli.Services",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2026-04-18T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2026-04-18 - 2026-04-18",
+        "changes": ["CliConfig", "CliLogger", "Converter service"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/cli/services/.contract.json
+++ b/hashes.md/cli/services/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Cli.Services",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "CLI service layer",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/cli/services/.logic.md
+++ b/hashes.md/cli/services/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Cli.Services - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+CLI service layer

--- a/hashes.md/cli/services/CliConfig.hash.md
+++ b/hashes.md/cli/services/CliConfig.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Cli.Services.CliConfig
+
+/** WebUsdFramework.Cli.Services.CliConfig - Cli.Services.CliConfig module */
+
+### [Signatures]
+- `CliConfigShape()`
+- `CliConfigLive()`
+- `parseArgs()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/cli/services/.contract.json"
+- logic: "@root/hashes.md/cli/services/.logic.md"
+- chronos: "@root/hashes.md/cli/services/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/cli/services/CliLogger.hash.md
+++ b/hashes.md/cli/services/CliLogger.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Cli.Services.CliLogger
+
+/** WebUsdFramework.Cli.Services.CliLogger - CliLogger Service */
+
+### [Signatures]
+- `CliLoggerShape()`
+- `CliLoggerLive()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/cli/services/.contract.json"
+- logic: "@root/hashes.md/cli/services/.logic.md"
+- chronos: "@root/hashes.md/cli/services/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/cli/services/Converter.hash.md
+++ b/hashes.md/cli/services/Converter.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Cli.Services.Converter
+
+/** WebUsdFramework.Cli.Services.Converter - Cli.Services.Converter module */
+
+### [Signatures]
+- `ConverterShape()`
+- `ConverterLive()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/cli/services/.contract.json"
+- logic: "@root/hashes.md/cli/services/.logic.md"
+- chronos: "@root/hashes.md/cli/services/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/constants/.chronos.json
+++ b/hashes.md/constants/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Constants",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-22 - 2025-11-15",
+        "changes": ["Initial USD constants", "ZIP format constants", "Animation FPS constants", "Skeleton constants"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/constants/.contract.json
+++ b/hashes.md/constants/.contract.json
@@ -1,0 +1,39 @@
+{
+  "ForensicShard": "WebUsdFramework.Constants",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "USD_NODE_TYPES": {
+      "type": "const object",
+      "values": ["Xform", "Scope", "Mesh", "Material", "Shader", "Camera"],
+      "immutable": true
+    },
+    "USD_ROOT_PATHS": {
+      "type": "const object", 
+      "values": ["/Root", "/Root/Scenes", "/Root/Materials"],
+      "immutable": true
+    },
+    "USD_PROPERTIES": {
+      "type": "const object",
+      "values": ["ANCHORING_TYPE", "XFORM_OP_TRANSFORM", "MATERIAL_BINDING"],
+      "immutable": true
+    },
+    "USD_PROPERTY_TYPES": {
+      "type": "const object",
+      "values": ["TOKEN", "STRING_ARRAY", "REL", "FLOAT"],
+      "immutable": true
+    },
+    "ZIP_VERSION": {
+      "type": "const object",
+      "values": ["MAJOR", "MINOR"],
+      "immutable": true
+    }
+  },
+  "Invariants": [
+    "All constants are readonly/immutable",
+    "No runtime mutations permitted",
+    "Type-safe token strings for USD schema"
+  ],
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/constants/.logic.md
+++ b/hashes.md/constants/.logic.md
@@ -1,0 +1,35 @@
+# WebUsdFramework.Constants - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → Constant value contracts
+- `.logic.md` → Constant governance rules
+- `.chronos.json` → Evolution of constants
+
+## Governance Laws
+
+### 1. Immutability Law
+All constants MUST be declared with `as const` or `Readonly<T>`.
+No runtime modification is permitted.
+
+### 2. Namespace Law
+Constants are organized by domain:
+- `USD_*` → USD schema tokens and paths
+- `ZIP_*` → ZIP/USDZ archive format constants
+- `DEFAULT_*` → Framework default values
+
+### 3. Type Safety Law
+All string constants must be typed as `const` to enable literal type inference.
+
+## USD Schema Constants
+```
+USD_NODE_TYPES: Defines valid USD prim types
+USD_ROOT_PATHS: Standard USD stage hierarchy
+USD_PROPERTIES: Common USD property names
+USD_PROPERTY_TYPES: Type annotations for properties
+```
+
+## ZIP Format Constants
+```
+ZIP_VERSION: ZIP specification version bytes
+USDZ_ALIGNMENT: 64-byte alignment requirement
+```

--- a/hashes.md/constants/animation.hash.md
+++ b/hashes.md/constants/animation.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `DEFAULT_FPS: number`
 - `USDA_TIME_CODES_PER_SECOND: number`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/constants/.contract.json"
+- logic: "@root/hashes.md/constants/.logic.md"
+- chronos: "@root/hashes.md/constants/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/converters/gltf/helpers/animation-processor.hash.md"

--- a/hashes.md/constants/config.hash.md
+++ b/hashes.md/constants/config.hash.md
@@ -11,6 +11,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - `DEFAULT_CONFIG: Readonly<FrameworkOptions>`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/constants/.contract.json"
+- logic: "@root/hashes.md/constants/.logic.md"
+- chronos: "@root/hashes.md/constants/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/index.hash.md"

--- a/hashes.md/constants/errors.hash.md
+++ b/hashes.md/constants/errors.hash.md
@@ -14,6 +14,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Governance]
 - Propagation_Law: Error codes consumed by FrameworkError; never exposed raw
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/constants/.contract.json"
+- logic: "@root/hashes.md/constants/.logic.md"
+- chronos: "@root/hashes.md/constants/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/errors.hash.md"

--- a/hashes.md/constants/index.hash.md
+++ b/hashes.md/constants/index.hash.md
@@ -14,5 +14,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Governance]
 - Export_Law: Single opaque barrel; no direct deep imports from consumers
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/constants/.contract.json"
+- logic: "@root/hashes.md/constants/.logic.md"
+- chronos: "@root/hashes.md/constants/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/constants/skeleton.hash.md
+++ b/hashes.md/constants/skeleton.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `MAX_JOINTS_PER_SKIN: number`
 - `SKELETON_LOD_THRESHOLD: number`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/constants/.contract.json"
+- logic: "@root/hashes.md/constants/.logic.md"
+- chronos: "@root/hashes.md/constants/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/converters/gltf/helpers/skeleton-processor.hash.md"

--- a/hashes.md/constants/usd.hash.md
+++ b/hashes.md/constants/usd.hash.md
@@ -13,6 +13,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `USD_METERS_PER_UNIT: number`
 - `USD_SCHEMA_TOKENS: Readonly<Record<string, string>>`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/constants/.contract.json"
+- logic: "@root/hashes.md/constants/.logic.md"
+- chronos: "@root/hashes.md/constants/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/core/usd-node.hash.md"

--- a/hashes.md/constants/zip.hash.md
+++ b/hashes.md/constants/zip.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `USDZ_ALIGNMENT: number`
 - `ZIP_LOCAL_FILE_HEADER_MAGIC: number`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/constants/.contract.json"
+- logic: "@root/hashes.md/constants/.logic.md"
+- chronos: "@root/hashes.md/constants/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/schemas/zip-writer.hash.md"

--- a/hashes.md/converters/.chronos.json
+++ b/hashes.md/converters/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-22 - 2026-04-27",
+        "changes": ["GLTF converter", "OBJ converter", "STL converter", "FBX converter", "PLY converter", "USDC binary output"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/.contract.json
+++ b/hashes.md/converters/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "Converter orchestration layer",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/.logic.md
+++ b/hashes.md/converters/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Converters - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+Converter orchestration layer

--- a/hashes.md/converters/fbx/.chronos.json
+++ b/hashes.md/converters/fbx/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Fbx",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-11-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-11-22 - 2025-11-22",
+        "changes": ["FBX to GLB delegation"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/fbx/.contract.json
+++ b/hashes.md/converters/fbx/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Fbx",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "FBX conversion utilities",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/fbx/.logic.md
+++ b/hashes.md/converters/fbx/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Converters.Fbx - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+FBX conversion utilities

--- a/hashes.md/converters/fbx/fbx-to-gltf-via-tool.hash.md
+++ b/hashes.md/converters/fbx/fbx-to-gltf-via-tool.hash.md
@@ -11,6 +11,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - `convertFbxToGlb(fbxPath: string): Promise<string>`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/fbx/.contract.json"
+- logic: "@root/hashes.md/converters/fbx/.logic.md"
+- chronos: "@root/hashes.md/converters/fbx/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/converters/fbx/index.hash.md"

--- a/hashes.md/converters/fbx/index.hash.md
+++ b/hashes.md/converters/fbx/index.hash.md
@@ -11,6 +11,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - `class FbxConverter implements IConverter`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/fbx/.contract.json"
+- logic: "@root/hashes.md/converters/fbx/.logic.md"
+- chronos: "@root/hashes.md/converters/fbx/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/converters/fbx/fbx-to-gltf-via-tool.hash.md"

--- a/hashes.md/converters/gltf/.chronos.json
+++ b/hashes.md/converters/gltf/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Gltf",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-22 - 2025-11-14",
+        "changes": ["Initial GLTF converter", "Animation support", "Skeleton processing", "PBR materials", "Extensions support"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/gltf/.contract.json
+++ b/hashes.md/converters/gltf/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Gltf",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "GLTF/GLB to USDZ conversion",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/gltf/.logic.md
+++ b/hashes.md/converters/gltf/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Converters.Gltf - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+GLTF/GLB to USDZ conversion

--- a/hashes.md/converters/gltf/extensions/.chronos.json
+++ b/hashes.md/converters/gltf/extensions/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Gltf.Extensions",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-11-13T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-11-13 - 2025-11-14",
+        "changes": ["KHR_lights_punctual", "KHR_xmp_json_ld", "EXT_mesh_gpu_instancing", "PBR extension processors"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/gltf/extensions/.contract.json
+++ b/hashes.md/converters/gltf/extensions/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Gltf.Extensions",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "GLTF extension handlers",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/gltf/extensions/.logic.md
+++ b/hashes.md/converters/gltf/extensions/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Converters.Gltf.Extensions - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+GLTF extension handlers

--- a/hashes.md/converters/gltf/extensions/extension-factory.hash.md
+++ b/hashes.md/converters/gltf/extensions/extension-factory.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class ExtensionFactory`
 - `createProcessor(extName: string): IExtensionProcessor | null`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/converters/gltf/extensions/extension-processor.hash.md"

--- a/hashes.md/converters/gltf/extensions/extension-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/extension-processor.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class ExtensionProcessor`
 - `process(node: Node, usdNode: UsdNode): void`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/converters/gltf/extensions/extension-factory.hash.md"

--- a/hashes.md/converters/gltf/extensions/index.hash.md
+++ b/hashes.md/converters/gltf/extensions/index.hash.md
@@ -1,0 +1,26 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Index
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Index - Barrel export for all GLTF extension processors */
+
+### [Signatures]
+- Re-exports: extension-processor, extension-factory, all PBR processors, light-processor, instancing-processor, xmp-processor
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/.chronos.json"
+
+### [Governance]
+- Export_Law: Single barrel for all extension processors
+- No direct deep imports from consumers
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
+- depends_on: "@root/hashes.md/converters/gltf/extensions/extension-processor.hash.md"
+- depends_on: "@root/hashes.md/converters/gltf/extensions/extension-factory.hash.md"

--- a/hashes.md/converters/gltf/extensions/instancing-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/instancing-processor.hash.md
@@ -12,5 +12,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class InstancingProcessor implements IExtensionProcessor`
 - `process(node: Node, context: Context): void`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/light-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/light-processor.hash.md
@@ -12,5 +12,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class LightProcessor implements IExtensionProcessor`
 - `process(node: Node, context: Context): void`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/.chronos.json
+++ b/hashes.md/converters/gltf/extensions/processors/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Gltf.Extensions.Processors",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-11-13T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-11-13 - 2025-11-14",
+        "changes": ["Anisotropy", "Clearcoat", "Dispersion", "Emissive strength", "IOR", "Iridescence", "Sheen", "Transmission", "Volume", "Unlit"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/gltf/extensions/processors/.contract.json
+++ b/hashes.md/converters/gltf/extensions/processors/.contract.json
@@ -1,0 +1,27 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Gltf.Extensions.Processors",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "PBR Processors": {
+      "description": "GLTF PBR extension processors for USD material translation",
+      "implementors": [
+        "pbr-anisotropy-processor",
+        "pbr-clearcoat-processor",
+        "pbr-diffuse-transmission-processor",
+        "pbr-dispersion-processor",
+        "pbr-emissive-strength-processor",
+        "pbr-ior-processor",
+        "pbr-iridescence-processor",
+        "pbr-sheen-processor",
+        "pbr-specular-processor",
+        "pbr-specular-glossiness-processor",
+        "pbr-transmission-processor",
+        "pbr-unlit-processor",
+        "pbr-volume-processor"
+      ]
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/gltf/extensions/processors/.logic.md
+++ b/hashes.md/converters/gltf/extensions/processors/.logic.md
@@ -1,0 +1,39 @@
+# WebUsdFramework.Converters.Gltf.Extensions.Processors - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → PBR processor contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## PBR Extension Processing
+
+### Supported Extensions
+- KHR_materials_anisotropy
+- KHR_materials_clearcoat
+- KHR_materials_diffuse_transmission
+- KHR_materials_dispersion
+- KHR_materials_emissive_strength
+- KHR_materials_ior
+- KHR_materials_iridescence
+- KHR_materials_sheen
+- KHR_materials_specular
+- KHR_materials_transmission
+- KHR_materials_unlit
+- KHR_materials_volume
+- KHR_materials_pbrSpecularGlossiness
+
+### Processing Pipeline
+1. Detect extension in GLTF material
+2. Extract extension parameters
+3. Map to USD PreviewSurface inputs
+4. Generate USD material nodes
+5. Connect texture samplers if present
+
+### Governance
+- All processors implement IExtensionProcessor
+- Texture handling delegated to texture-utils
+- USD material output must be valid USDA
+
+## History
+- Epoch 1: 2025-11-13 - Initial PBR extension support
+- Epoch 2: 2025-11-14 - Complete PBR extension coverage

--- a/hashes.md/converters/gltf/extensions/processors/pbr-anisotropy-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-anisotropy-processor.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrAnisotropyProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrAnisotropyProcessor - PBR Anisotropy Extension Processor */
+
+### [Signatures]
+- `PBRAnisotropyProcessor()`
+- `canProcess()`
+- `process()`
+- `getTexCoord()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/pbr-clearcoat-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-clearcoat-processor.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrClearcoatProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrClearcoatProcessor - PBR Clearcoat Extension Processor */
+
+### [Signatures]
+- `PBRClearcoatProcessor()`
+- `canProcess()`
+- `process()`
+- `getTexCoord()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/pbr-diffuse-transmission-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-diffuse-transmission-processor.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrDiffuseTransmissionProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrDiffuseTransmissionProcessor - PBR Diffuse Transmission Extension Processor */
+
+### [Signatures]
+- `PBRDiffuseTransmissionProcessor()`
+- `canProcess()`
+- `process()`
+- `getTexCoord()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/pbr-dispersion-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-dispersion-processor.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrDispersionProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrDispersionProcessor - PBR Dispersion Extension Processor */
+
+### [Signatures]
+- `PBRDispersionProcessor()`
+- `canProcess()`
+- `process()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/pbr-emissive-strength-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-emissive-strength-processor.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrEmissiveStrengthProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrEmissiveStrengthProcessor - PBR Emissive Strength Extension Processor */
+
+### [Signatures]
+- `PBREmissiveStrengthProcessor()`
+- `canProcess()`
+- `process()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/pbr-ior-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-ior-processor.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrIorProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrIorProcessor - PBR IOR Extension Processor */
+
+### [Signatures]
+- `PBRIORProcessor()`
+- `canProcess()`
+- `process()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/pbr-iridescence-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-iridescence-processor.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrIridescenceProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrIridescenceProcessor - PBR Iridescence Extension Processor */
+
+### [Signatures]
+- `PBRIridescenceProcessor()`
+- `canProcess()`
+- `process()`
+- `getTexCoord()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/pbr-sheen-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-sheen-processor.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrSheenProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrSheenProcessor - PBR Sheen Extension Processor */
+
+### [Signatures]
+- `PBRSheenProcessor()`
+- `canProcess()`
+- `process()`
+- `getTexCoord()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/pbr-specular-glossiness-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-specular-glossiness-processor.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrSpecularGlossinessProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrSpecularGlossinessProcessor - PBR Specular Glossiness Extension Processor */
+
+### [Signatures]
+- `PBRSpecularGlossinessProcessor()`
+- `canProcess()`
+- `process()`
+- `getTexCoord()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/pbr-specular-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-specular-processor.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrSpecularProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrSpecularProcessor - PBR Specular Extension Processor */
+
+### [Signatures]
+- `PBRSpecularProcessor()`
+- `canProcess()`
+- `process()`
+- `getTexCoord()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/pbr-transmission-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-transmission-processor.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrTransmissionProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrTransmissionProcessor - PBR Transmission Extension Processor */
+
+### [Signatures]
+- `PBRTransmissionProcessor()`
+- `canProcess()`
+- `process()`
+- `getTexCoord()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/pbr-unlit-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-unlit-processor.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrUnlitProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrUnlitProcessor - PBR Unlit Extension Processor */
+
+### [Signatures]
+- `PBRUnlitProcessor()`
+- `canProcess()`
+- `process()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/pbr-volume-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/pbr-volume-processor.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrVolumeProcessor
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.PbrVolumeProcessor - PBR Volume Extension Processor */
+
+### [Signatures]
+- `PBRVolumeProcessor()`
+- `canProcess()`
+- `process()`
+- `getTexCoord()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/processors/texture-utils.hash.md
+++ b/hashes.md/converters/gltf/extensions/processors/texture-utils.hash.md
@@ -1,0 +1,25 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Extensions.Processors.TextureUtils
+
+/** WebUsdFramework.Converters.Gltf.Extensions.Processors.TextureUtils - Shared utility functions for extension processors */
+
+### [Signatures]
+- `generateTextureId()`
+- `getTextureFileBasename()`
+- `extractTextureTransform()`
+- `getTextureExtension()`
+- `getCleanTextureImage()`
+- `substring()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/extensions/xmp-processor.hash.md
+++ b/hashes.md/converters/gltf/extensions/xmp-processor.hash.md
@@ -12,5 +12,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class XmpProcessor implements IExtensionProcessor`
 - `process(node: Node, context: Context): void`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/extensions/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/extensions/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/extensions/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/gltf-converter.hash.md
+++ b/hashes.md/converters/gltf/gltf-converter.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class GltfConverter implements IConverter`
 - `convert(input: string, options: IConverterOptions): Promise<IConversionResult>`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/converters/shared/usd-geometry-builder.hash.md"

--- a/hashes.md/converters/gltf/gltf-parser.hash.md
+++ b/hashes.md/converters/gltf/gltf-parser.hash.md
@@ -12,5 +12,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class GltfParser`
 - `parse(buffer: Uint8Array): Promise<Document>`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/helpers/.chronos.json
+++ b/hashes.md/converters/gltf/helpers/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Gltf.Helpers",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-11-04T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-11-04 - 2025-11-13",
+        "changes": ["Animation processor", "Skeleton processor", "Geometry processor", "Hierarchy builder"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/gltf/helpers/.contract.json
+++ b/hashes.md/converters/gltf/helpers/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Gltf.Helpers",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "GLTF conversion helpers",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/gltf/helpers/.logic.md
+++ b/hashes.md/converters/gltf/helpers/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Converters.Gltf.Helpers - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+GLTF conversion helpers

--- a/hashes.md/converters/gltf/helpers/animation-processor-factory.hash.md
+++ b/hashes.md/converters/gltf/helpers/animation-processor-factory.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class AnimationProcessorFactory`
 - `create(channel: AnimationChannel): IAnimationProcessor`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/helpers/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/helpers/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/helpers/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/converters/gltf/helpers/animation-processor.hash.md"

--- a/hashes.md/converters/gltf/helpers/animation-processor.hash.md
+++ b/hashes.md/converters/gltf/helpers/animation-processor.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class AnimationProcessor`
 - `processAnimations(): UsdNode[]`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/helpers/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/helpers/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/helpers/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/utils/time-code-converter.hash.md"

--- a/hashes.md/converters/gltf/helpers/geometry-processor.hash.md
+++ b/hashes.md/converters/gltf/helpers/geometry-processor.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class GeometryProcessor`
 - `process(mesh: Mesh): UsdNode[]`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/helpers/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/helpers/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/helpers/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/converters/shared/usd-geometry-builder.hash.md"

--- a/hashes.md/converters/gltf/helpers/gltf-transform-helpers.hash.md
+++ b/hashes.md/converters/gltf/helpers/gltf-transform-helpers.hash.md
@@ -11,5 +11,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - `getMeshTriangles(mesh: Mesh): number`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/helpers/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/helpers/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/helpers/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/helpers/processors/.chronos.json
+++ b/hashes.md/converters/gltf/helpers/processors/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Gltf.Helpers.Processors",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-11-04T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-11-04 - 2025-11-13",
+        "changes": ["Node animation", "Skeleton animation", "Morph target animation"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/gltf/helpers/processors/.contract.json
+++ b/hashes.md/converters/gltf/helpers/processors/.contract.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Gltf.Helpers.Processors",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "Animation Processors": {
+      "description": "GLTF animation channel processors for USD SkelAnimation",
+      "implementors": [
+        "node-animation-processor",
+        "skeleton-animation-processor",
+        "morph-target-animation-processor"
+      ]
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/gltf/helpers/processors/.logic.md
+++ b/hashes.md/converters/gltf/helpers/processors/.logic.md
@@ -1,0 +1,29 @@
+# WebUsdFramework.Converters.Gltf.Helpers.Processors - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → Animation processor contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Animation Processing
+
+### Supported Animation Types
+- Node transform animation (translation, rotation, scale)
+- Skeleton joint animation
+- Morph target (blend shape) animation
+
+### Processing Pipeline
+1. Parse animation channels from GLTF
+2. Classify channel type (node/skeleton/morph)
+3. Convert time codes using TimeCodeConverter
+4. Generate USD time-sampled properties
+5. Connect to appropriate USD prim
+
+### Governance
+- All processors use Factory pattern via AnimationProcessorFactory
+- Time codes normalized to 120 FPS
+- USD output must use valid xformOp syntax
+
+## History
+- Epoch 1: 2025-11-04 - Initial animation support
+- Epoch 2: 2025-11-13 - Skeleton and morph target support

--- a/hashes.md/converters/gltf/helpers/processors/morph-target-animation-processor.hash.md
+++ b/hashes.md/converters/gltf/helpers/processors/morph-target-animation-processor.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Helpers.Processors.MorphTargetAnimationProcessor
+
+/** WebUsdFramework.Converters.Gltf.Helpers.Processors.MorphTargetAnimationProcessor - Converts morph target (blend shape) animations from GLTF to USD format. */
+
+### [Signatures]
+- `MorphTargetAnimationProcessor()`
+- `canProcess()`
+- `process()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/helpers/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/helpers/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/helpers/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/helpers/processors/node-animation-processor.hash.md
+++ b/hashes.md/converters/gltf/helpers/processors/node-animation-processor.hash.md
@@ -1,0 +1,22 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Helpers.Processors.NodeAnimationProcessor
+
+/** WebUsdFramework.Converters.Gltf.Helpers.Processors.NodeAnimationProcessor - Converts node animations from GLTF to USD format. */
+
+### [Signatures]
+- `NodeAnimationProcessor()`
+- `canProcess()`
+- `process()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/helpers/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/helpers/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/helpers/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/helpers/processors/skeleton-animation-processor.hash.md
+++ b/hashes.md/converters/gltf/helpers/processors/skeleton-animation-processor.hash.md
@@ -1,0 +1,24 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Gltf.Helpers.Processors.SkeletonAnimationProcessor
+
+/** WebUsdFramework.Converters.Gltf.Helpers.Processors.SkeletonAnimationProcessor - Converts skeleton animations from GLTF to USD format. */
+
+### [Signatures]
+- `SkeletonAnimationProcessor()`
+- `setSkeletonAnimationSources()`
+- `convertToContinuousTimeSamples()`
+- `canProcess()`
+- `process()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/helpers/processors/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/helpers/processors/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/helpers/processors/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/helpers/skeleton-processor.hash.md
+++ b/hashes.md/converters/gltf/helpers/skeleton-processor.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class SkeletonProcessor`
 - `process(skin: Skin): { skelRoot: UsdNode, skeleton: UsdNode }`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/helpers/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/helpers/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/helpers/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/constants/skeleton.hash.md"

--- a/hashes.md/converters/gltf/helpers/usd-hierarchy-builder.hash.md
+++ b/hashes.md/converters/gltf/helpers/usd-hierarchy-builder.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class UsdHierarchyBuilder`
 - `build(rootNode: Node): UsdNode`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/helpers/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/helpers/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/helpers/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/core/usd-node.hash.md"

--- a/hashes.md/converters/gltf/helpers/vertex-color-baker.hash.md
+++ b/hashes.md/converters/gltf/helpers/vertex-color-baker.hash.md
@@ -11,5 +11,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - `bakeVertexColors(mesh: Mesh): void`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/helpers/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/helpers/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/helpers/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/gltf/index.hash.md
+++ b/hashes.md/converters/gltf/index.hash.md
@@ -11,6 +11,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - Re-exports GltfConverter
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/gltf/.contract.json"
+- logic: "@root/hashes.md/converters/gltf/.logic.md"
+- chronos: "@root/hashes.md/converters/gltf/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/converters/gltf/gltf-converter.hash.md"

--- a/hashes.md/converters/obj/.chronos.json
+++ b/hashes.md/converters/obj/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Obj",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-28T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-28 - 2025-10-30",
+        "changes": ["OBJ converter", "MTL support", "Texture handling"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/obj/.contract.json
+++ b/hashes.md/converters/obj/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Obj",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "OBJ to USDZ conversion",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/obj/.logic.md
+++ b/hashes.md/converters/obj/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Converters.Obj - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+OBJ to USDZ conversion

--- a/hashes.md/converters/obj/helpers/.chronos.json
+++ b/hashes.md/converters/obj/helpers/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Obj.Helpers",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-28T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-28 - 2025-10-30",
+        "changes": ["OBJ to USD adapter", "Mesh data mapping"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/obj/helpers/.contract.json
+++ b/hashes.md/converters/obj/helpers/.contract.json
@@ -1,0 +1,20 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Obj.Helpers",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "ObjToUsdAdapter": {
+      "input": "ParsedObjData, ObjConverterConfig",
+      "output": "UsdNode (root)",
+      "guarantees": ["group-to-mesh", "material-binding", "uv-mapping"]
+    }
+  },
+  "Interfaces": {
+    "IObjToUsdAdapter": {
+      "methods": ["adapt(objData, config): UsdNode"],
+      "implementors": ["ObjToUsdAdapter"]
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/obj/helpers/.logic.md
+++ b/hashes.md/converters/obj/helpers/.logic.md
@@ -1,0 +1,28 @@
+# WebUsdFramework.Converters.Obj.Helpers - Business Logic
+
+> **OBJ-specific USD adaptation. Bridges parsed OBJ data to UsdNode.**
+
+## Core Business Rules
+
+### 1. Adapter Contract
+- Input: parsed vertices, normals, UVs, faces, groups, materials
+- Output: `UsdNode` tree with `Mesh` prims and `Material` bindings
+- Must handle missing normals (auto-generate)
+- Must handle missing UVs (skip texcoord)
+
+### 2. Group-to-Mesh Mapping
+- Each `g` (group) or `o` (object) becomes a `Mesh` prim
+- Face indices offset to 0-based
+- `faceVertexCounts` = [3, 3, 3, ...] (all triangles)
+- `faceVertexIndices` = flattened index array
+
+### 3. Material Binding
+- `usemtl` name → `Material_` + sanitized name
+- `material:binding` rel set on each mesh
+- MTL properties converted to `UsdPreviewSurface` inputs
+- Texture paths resolved relative to OBJ file
+
+## Governance
+- Single file: `obj-to-usd-adapter.ts`
+- Depends only on `core/usd-node.ts` and `utils/`
+- No filesystem access (data already parsed)

--- a/hashes.md/converters/obj/helpers/obj-to-usd-adapter.hash.md
+++ b/hashes.md/converters/obj/helpers/obj-to-usd-adapter.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class ObjToUsdAdapter`
 - `adapt(scene: ObjScene, builder: UsdGeometryBuilder): UsdNode[]`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/obj/helpers/.contract.json"
+- logic: "@root/hashes.md/converters/obj/helpers/.logic.md"
+- chronos: "@root/hashes.md/converters/obj/helpers/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/converters/shared/usd-geometry-builder.hash.md"

--- a/hashes.md/converters/obj/index.hash.md
+++ b/hashes.md/converters/obj/index.hash.md
@@ -11,6 +11,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - Re-exports ObjConverter
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/obj/.contract.json"
+- logic: "@root/hashes.md/converters/obj/.logic.md"
+- chronos: "@root/hashes.md/converters/obj/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/converters/obj/obj-converter.hash.md"

--- a/hashes.md/converters/obj/obj-converter.hash.md
+++ b/hashes.md/converters/obj/obj-converter.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class ObjConverter implements IConverter`
 - `convert(input: string, options: IConverterOptions): Promise<IConversionResult>`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/obj/.contract.json"
+- logic: "@root/hashes.md/converters/obj/.logic.md"
+- chronos: "@root/hashes.md/converters/obj/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/converters/shared/usd-geometry-builder.hash.md"

--- a/hashes.md/converters/obj/obj-mesh-parser.hash.md
+++ b/hashes.md/converters/obj/obj-mesh-parser.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class ObjMeshParser`
 - `parseVertices(lines: string[]): ObjGeometry`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/obj/.contract.json"
+- logic: "@root/hashes.md/converters/obj/.logic.md"
+- chronos: "@root/hashes.md/converters/obj/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/converters/obj/obj-parser.hash.md"

--- a/hashes.md/converters/obj/obj-parser.hash.md
+++ b/hashes.md/converters/obj/obj-parser.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class ObjParser`
 - `parse(buffer: Uint8Array): Promise<ObjScene>`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/obj/.contract.json"
+- logic: "@root/hashes.md/converters/obj/.logic.md"
+- chronos: "@root/hashes.md/converters/obj/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/converters/obj/obj-mesh-parser.hash.md"

--- a/hashes.md/converters/ply/.chronos.json
+++ b/hashes.md/converters/ply/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Ply",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2026-04-18T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2026-04-18 - 2026-04-26",
+        "changes": ["PLY parser", "PLY converter", "Mesh decimator", "Point cloud support"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/ply/.contract.json
+++ b/hashes.md/converters/ply/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Ply",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "PLY to USDZ conversion",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/ply/.logic.md
+++ b/hashes.md/converters/ply/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Converters.Ply - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+PLY to USDZ conversion

--- a/hashes.md/converters/ply/index.hash.md
+++ b/hashes.md/converters/ply/index.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Ply.Index
+
+/** WebUsdFramework.Converters.Ply.Index - PLY to USDZ Converter */
+
+### [Signatures]
+- `export` barrel re-exports
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/ply/.contract.json"
+- logic: "@root/hashes.md/converters/ply/.logic.md"
+- chronos: "@root/hashes.md/converters/ply/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/ply/mesh-decimator.hash.md
+++ b/hashes.md/converters/ply/mesh-decimator.hash.md
@@ -1,0 +1,24 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Ply.MeshDecimator
+
+/** WebUsdFramework.Converters.Ply.MeshDecimator - WebUsdFramework.Converters.Ply.MeshDecimator - O(n) vertex clustering decimation for large meshes */
+
+### [Signatures]
+- `DecimatedMesh()`
+- `decimateMesh()`
+- `Float32Array()`
+- `computeFaceNormals()`
+- `createFillArray()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/ply/.contract.json"
+- logic: "@root/hashes.md/converters/ply/.logic.md"
+- chronos: "@root/hashes.md/converters/ply/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/ply/ply-converter.hash.md
+++ b/hashes.md/converters/ply/ply-converter.hash.md
@@ -1,0 +1,28 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Ply.PlyConverter
+
+/** WebUsdFramework.Converters.Ply.PlyConverter - WebUsdFramework.Converters.Ply.PlyConverter - Main PLY to USDZ converter */
+
+### [Signatures]
+- `convertPlyToUsdz()`
+- `fmtFloat()`
+- `formatExtent()`
+- `centerGeometry()`
+- `downsamplePointCloud()`
+- `Float32Array()`
+- `buildMeshNode()`
+- `buildPointsNode()`
+- `createBasicMaterial()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/ply/.contract.json"
+- logic: "@root/hashes.md/converters/ply/.logic.md"
+- chronos: "@root/hashes.md/converters/ply/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/ply/ply-parser.hash.md
+++ b/hashes.md/converters/ply/ply-parser.hash.md
@@ -1,0 +1,29 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Ply.PlyParser
+
+/** WebUsdFramework.Converters.Ply.PlyParser - WebUsdFramework.Converters.Ply.PlyParser - Parses ASCII and Binary PLY files into geometry objects */
+
+### [Signatures]
+- `PlyMeshData()`
+- `PlyParserConfig()`
+- `parsePly()`
+- `parsePlyFile()`
+- `parseHeader()`
+- `readValue()`
+- `getPropertyRole()`
+- `parseAsciiData()`
+- `Float32Array()`
+- `parseBinaryData()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/ply/.contract.json"
+- logic: "@root/hashes.md/converters/ply/.logic.md"
+- chronos: "@root/hashes.md/converters/ply/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/.chronos.json
+++ b/hashes.md/converters/shared/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Shared",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-22 - 2026-04-27",
+        "changes": ["USD geometry builder", "USD material builder", "USD packaging", "USDZ ZIP writer", "USDC encoder", "Debug writer"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/shared/.contract.json
+++ b/hashes.md/converters/shared/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Shared",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "Shared converter utilities",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/shared/.logic.md
+++ b/hashes.md/converters/shared/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Converters.Shared - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+Shared converter utilities

--- a/hashes.md/converters/shared/debug-writer.hash.md
+++ b/hashes.md/converters/shared/debug-writer.hash.md
@@ -11,5 +11,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - `writeDebugUsda(path: string, content: string): void`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/.contract.json"
+- logic: "@root/hashes.md/converters/shared/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usd-geometry-builder.hash.md
+++ b/hashes.md/converters/shared/usd-geometry-builder.hash.md
@@ -15,6 +15,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Governance]
 - Must delegate all USDA raw string building to core UsdNode hierarchy
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/.contract.json"
+- logic: "@root/hashes.md/converters/shared/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/core/usd-node.hash.md"

--- a/hashes.md/converters/shared/usd-material-builder.hash.md
+++ b/hashes.md/converters/shared/usd-material-builder.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class UsdMaterialBuilder`
 - `buildMaterial(mat: PbrMaterial): UsdNode`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/.contract.json"
+- logic: "@root/hashes.md/converters/shared/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/core/usd-node.hash.md"

--- a/hashes.md/converters/shared/usd-packaging.hash.md
+++ b/hashes.md/converters/shared/usd-packaging.hash.md
@@ -11,6 +11,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - `packUsdz(usda: string, assets: AssetRecord[]): Promise<Blob>`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/.contract.json"
+- logic: "@root/hashes.md/converters/shared/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/converters/shared/usdz-zip-writer.hash.md"

--- a/hashes.md/converters/shared/usd-root-builder.hash.md
+++ b/hashes.md/converters/shared/usd-root-builder.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class UsdRootBuilder`
 - `buildRoot(): UsdNode`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/.contract.json"
+- logic: "@root/hashes.md/converters/shared/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/core/usd-node.hash.md"

--- a/hashes.md/converters/shared/usdc-writer.hash.md
+++ b/hashes.md/converters/shared/usdc-writer.hash.md
@@ -1,0 +1,27 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.UsdcWriter
+
+/** WebUsdFramework.Converters.Shared.UsdcWriter - WebUsdFramework.Converters.Shared.UsdcWriter — Pixar Crate (USDC) binary layer encoder */
+
+### [Signatures]
+- `USDC_MAGIC()`
+- `USDC_BOOTSTRAP_SIZE()`
+- `UsdcVersion()`
+- `UsdcSection()`
+- `writeBootstrap()`
+- `tocByteLength()`
+- `writeTOC()`
+- `charCodeAt()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/.contract.json"
+- logic: "@root/hashes.md/converters/shared/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/.chronos.json
+++ b/hashes.md/converters/shared/usdc/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Shared.Usdc",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2026-04-25T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2026-04-25 - 2026-04-27",
+        "changes": ["LZ4 codec", "Integer coding", "Token/Strings sections", "Fields/Fieldsets", "Paths/Specs", "Array values", "Value representations", "Layer builder", "USD Node adapter"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/shared/usdc/.contract.json
+++ b/hashes.md/converters/shared/usdc/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Shared.Usdc",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "USDC binary format writers",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/shared/usdc/.logic.md
+++ b/hashes.md/converters/shared/usdc/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Converters.Shared.Usdc - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+USDC binary format writers

--- a/hashes.md/converters/shared/usdc/array-values.hash.md
+++ b/hashes.md/converters/shared/usdc/array-values.hash.md
@@ -1,0 +1,28 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.ArrayValues
+
+/** WebUsdFramework.Converters.Shared.Usdc.ArrayValues - WebUsdFramework.Converters.Shared.Usdc.ArrayValues — encoders for the */
+
+### [Signatures]
+- `COMPRESSION_THRESHOLD_BYTES()`
+- `arrayValueRep()`
+- `encodeFloatArray()`
+- `encodeVec3fArray()`
+- `encodeVec3fScalar()`
+- `encodeInt32Array()`
+- `encodeTokenArray()`
+- `decodeArrayHeader()`
+- `packArray()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/fields-section.hash.md
+++ b/hashes.md/converters/shared/usdc/fields-section.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.FieldsSection
+
+/** WebUsdFramework.Converters.Shared.Usdc.FieldsSection - WebUsdFramework.Converters.Shared.Usdc.FieldsSection — FIELDS section */
+
+### [Signatures]
+- `UsdcField()`
+- `encodeFieldsSection()`
+- `decodeFieldsSection()`
+- `Int32Array()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/fieldsets-section.hash.md
+++ b/hashes.md/converters/shared/usdc/fieldsets-section.hash.md
@@ -1,0 +1,27 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.FieldsetsSection
+
+/** WebUsdFramework.Converters.Shared.Usdc.FieldsetsSection - WebUsdFramework.Converters.Shared.Usdc.FieldSetsSection — FIELDSETS */
+
+### [Signatures]
+- `FIELD_SET_SENTINEL()`
+- `encodeFieldSetsSection()`
+- `decodeFieldSetsSection()`
+- `add()`
+- `read()`
+- `size()`
+- `toArray()`
+- `Uint8Array()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/index.hash.md
+++ b/hashes.md/converters/shared/usdc/index.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.Index
+
+/** WebUsdFramework.Converters.Shared.Usdc.Index - WebUsdFramework.Converters.Shared.Usdc — public re-exports for the */
+
+### [Signatures]
+- `export` barrel re-exports
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/integer-coding.hash.md
+++ b/hashes.md/converters/shared/usdc/integer-coding.hash.md
@@ -1,0 +1,27 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.IntegerCoding
+
+/** WebUsdFramework.Converters.Shared.Usdc.IntegerCoding - WebUsdFramework.Converters.Shared.Usdc.IntegerCoding — TfDelta variable-byte */
+
+### [Signatures]
+- `int32CompressedBound()`
+- `compressInt32()`
+- `decompressInt32()`
+- `int64CompressedBound()`
+- `compressInt64()`
+- `decompressInt64()`
+- `classifyInt32()`
+- `classifyInt64()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/layer-builder.hash.md
+++ b/hashes.md/converters/shared/usdc/layer-builder.hash.md
@@ -1,0 +1,34 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.LayerBuilder
+
+/** WebUsdFramework.Converters.Shared.Usdc.LayerBuilder - WebUsdFramework.Converters.Shared.Usdc.LayerBuilder — orchestrator that */
+
+### [Signatures]
+- `PrimHandle()`
+- `UsdcLayerBuilder()`
+- `buildSimpleUsdcLayer()`
+- `declarePrim()`
+- `addFloatAttribute()`
+- `addIntAttribute()`
+- `addTokenAttribute()`
+- `addFloatArrayAttribute()`
+- `addVec3fArrayAttribute()`
+- `addVec3fAttribute()`
+- `addIntArrayAttribute()`
+- `addTokenArrayAttribute()`
+- `addTokenListOpAttribute()`
+- `serialize()`
+- `internField()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/listop-values.hash.md
+++ b/hashes.md/converters/shared/usdc/listop-values.hash.md
@@ -1,0 +1,28 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.ListopValues
+
+/** WebUsdFramework.Converters.Shared.Usdc.ListopValues - WebUsdFramework.Converters.Shared.Usdc.ListOpValues — encoder for the */
+
+### [Signatures]
+- `SdfListOpSubListType()`
+- `IndexListOpInput()`
+- `encodeTokenListOp()`
+- `encodePathListOp()`
+- `decodeTokenListOp()`
+- `listOpValueRep()`
+- `format()`
+- `validateTokenIndices()`
+- `encodeIndexListOp()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/lz4-block.hash.md
+++ b/hashes.md/converters/shared/usdc/lz4-block.hash.md
@@ -1,0 +1,27 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.Lz4Block
+
+/** WebUsdFramework.Converters.Shared.Usdc.Lz4Block - WebUsdFramework.Converters.Shared.Usdc.Lz4Block — LZ4 block-format codec */
+
+### [Signatures]
+- `compress()`
+- `decompress()`
+- `hash4()`
+- `countMatch()`
+- `emitLiteralsOnly()`
+- `writeLength()`
+- `emitSequence()`
+- `emitFinalLiterals()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/paths-section.hash.md
+++ b/hashes.md/converters/shared/usdc/paths-section.hash.md
@@ -1,0 +1,28 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.PathsSection
+
+/** WebUsdFramework.Converters.Shared.Usdc.PathsSection - WebUsdFramework.Converters.Shared.Usdc.PathsSection — PATHS section */
+
+### [Signatures]
+- `PathNode()`
+- `EncodedPathTree()`
+- `decodePathsSection()`
+- `rebuildPathTree()`
+- `encodePathsSection()`
+- `emit()`
+- `Int32Array()`
+- `walk()`
+- `looksLikeLastSibling()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/property-parser.hash.md
+++ b/hashes.md/converters/shared/usdc/property-parser.hash.md
@@ -1,0 +1,21 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.PropertyParser
+
+/** WebUsdFramework.Converters.Shared.Usdc.PropertyParser - WebUsdFramework.Converters.Shared.Usdc.PropertyParser — parses the */
+
+### [Signatures]
+- `ListOpOpcode()`
+- `parsePropertyKey()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/specs-section.hash.md
+++ b/hashes.md/converters/shared/usdc/specs-section.hash.md
@@ -1,0 +1,24 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.SpecsSection
+
+/** WebUsdFramework.Converters.Shared.Usdc.SpecsSection - WebUsdFramework.Converters.Shared.Usdc.SpecsSection — SPECS section encoder. */
+
+### [Signatures]
+- `UsdcSpec()`
+- `encodeSpecsSection()`
+- `decodeSpecsSection()`
+- `validateUint32()`
+- `Uint8Array()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/strings-section.hash.md
+++ b/hashes.md/converters/shared/usdc/strings-section.hash.md
@@ -1,0 +1,27 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.StringsSection
+
+/** WebUsdFramework.Converters.Shared.Usdc.StringsSection - WebUsdFramework.Converters.Shared.Usdc.StringsSection — STRINGS section */
+
+### [Signatures]
+- `STRINGS_SECTION_HEADER_SIZE()`
+- `StringTable()`
+- `encodeStringsSection()`
+- `decodeStringsSection()`
+- `intern()`
+- `get()`
+- `count()`
+- `toArray()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/tokens-section.hash.md
+++ b/hashes.md/converters/shared/usdc/tokens-section.hash.md
@@ -1,0 +1,28 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.TokensSection
+
+/** WebUsdFramework.Converters.Shared.Usdc.TokensSection - WebUsdFramework.Converters.Shared.Usdc.TokensSection — TOKENS section */
+
+### [Signatures]
+- `TOKENS_SECTION_HEADER_SIZE()`
+- `TokenTable()`
+- `encodeTokensSection()`
+- `decodeTokensSection()`
+- `intern()`
+- `get()`
+- `count()`
+- `toArray()`
+- `buildFlatPayload()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/usd-node-adapter.hash.md
+++ b/hashes.md/converters/shared/usdc/usd-node-adapter.hash.md
@@ -1,0 +1,35 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.UsdNodeAdapter
+
+/** WebUsdFramework.Converters.Shared.Usdc.UsdNodeAdapter - WebUsdFramework.Converters.Shared.Usdc.UsdNodeAdapter — translate a */
+
+### [Signatures]
+- `AdaptedProperty()`
+- `adaptUsdNodeTree()`
+- `applyProperty()`
+- `encodeUsdNodeTreeToUsdc()`
+- `visit()`
+- `applyTypedAttribute()`
+- `applyScalarAttribute()`
+- `applyArrayAttribute()`
+- `coerceFiniteNumber()`
+- `coerceInteger()`
+- `coerceFloat32Array()`
+- `coerceInt32Array()`
+- `coerceStringArray()`
+- `skipped()`
+- `applyListOp()`
+- `describeType()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/usda-value-parser.hash.md
+++ b/hashes.md/converters/shared/usdc/usda-value-parser.hash.md
@@ -1,0 +1,23 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.UsdaValueParser
+
+/** WebUsdFramework.Converters.Shared.Usdc.UsdaValueParser - WebUsdFramework.Converters.Shared.Usdc.UsdaValueParser — parse the */
+
+### [Signatures]
+- `parseVec3fScalar()`
+- `parseVec2fScalar()`
+- `parseVec3fArray()`
+- `parseTuple()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdc/value-rep.hash.md
+++ b/hashes.md/converters/shared/usdc/value-rep.hash.md
@@ -1,0 +1,37 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.Usdc.ValueRep
+
+/** WebUsdFramework.Converters.Shared.Usdc.ValueRep - WebUsdFramework.Converters.Shared.Usdc.ValueRep — 8-byte tagged-union */
+
+### [Signatures]
+- `CrateDataType()`
+- `SdfSpecifier()`
+- `SdfPermission()`
+- `SdfVariability()`
+- `SdfSpecType()`
+- `ValueRepFields()`
+- `decodeValueRep()`
+- `inlineBool()`
+- `inlineInt()`
+- `inlineFloat()`
+- `extractInlineFloat()`
+- `inlineToken()`
+- `inlineSpecifier()`
+- `inlineVariability()`
+- `inlinePermission()`
+- `externalValueRep()`
+- `layout()`
+- `encodeValueRep()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/usdc/.contract.json"
+- logic: "@root/hashes.md/converters/shared/usdc/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/usdc/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdz-stream-writer.hash.md
+++ b/hashes.md/converters/shared/usdz-stream-writer.hash.md
@@ -1,0 +1,32 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Converters.Shared.UsdzStreamWriter
+
+/** WebUsdFramework.Converters.Shared.UsdzStreamWriter - WebUsdFramework.Converters.Shared.UsdzStreamWriter — streaming USDZ archive writer */
+
+### [Signatures]
+- `StreamingUsdzFile()`
+- `StreamingUsdzOptions()`
+- `writeUsdzToStream()`
+- `writeUsdzToFile()`
+- `getCrc32Table()`
+- `crc32OfChunks()`
+- `getDosTime()`
+- `getDosDate()`
+- `createLocalFileHeader()`
+- `createCentralDirectoryHeader()`
+- `createEndOfCentralDirectoryRecord()`
+- `writeChunk()`
+- `reject()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/.contract.json"
+- logic: "@root/hashes.md/converters/shared/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/converters/shared/usdz-zip-writer.hash.md
+++ b/hashes.md/converters/shared/usdz-zip-writer.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class UsdzZipWriterWrapper`
 - `addAsset(name: string, data: Uint8Array): void`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/shared/.contract.json"
+- logic: "@root/hashes.md/converters/shared/.logic.md"
+- chronos: "@root/hashes.md/converters/shared/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/schemas/zip-writer.hash.md"

--- a/hashes.md/converters/stl/.chronos.json
+++ b/hashes.md/converters/stl/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Stl",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-11-27T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-11-27 - 2025-11-27",
+        "changes": ["STL converter", "Binary/ASCII parsing"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/stl/.contract.json
+++ b/hashes.md/converters/stl/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Converters.Stl",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "STL to USDZ conversion",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/converters/stl/.logic.md
+++ b/hashes.md/converters/stl/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Converters.Stl - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+STL to USDZ conversion

--- a/hashes.md/converters/stl/index.hash.md
+++ b/hashes.md/converters/stl/index.hash.md
@@ -11,6 +11,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - Re-exports StlConverter
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/stl/.contract.json"
+- logic: "@root/hashes.md/converters/stl/.logic.md"
+- chronos: "@root/hashes.md/converters/stl/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/converters/stl/stl-converter.hash.md"

--- a/hashes.md/converters/stl/stl-converter.hash.md
+++ b/hashes.md/converters/stl/stl-converter.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class StlConverter implements IConverter`
 - `convert(input: string, options: IConverterOptions): Promise<IConversionResult>`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/stl/.contract.json"
+- logic: "@root/hashes.md/converters/stl/.logic.md"
+- chronos: "@root/hashes.md/converters/stl/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/converters/shared/usd-geometry-builder.hash.md"

--- a/hashes.md/converters/stl/stl-parser.hash.md
+++ b/hashes.md/converters/stl/stl-parser.hash.md
@@ -12,5 +12,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `class StlParser`
 - `parse(buffer: Uint8Array): Promise<StlGeometry>`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/converters/stl/.contract.json"
+- logic: "@root/hashes.md/converters/stl/.logic.md"
+- chronos: "@root/hashes.md/converters/stl/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/core/.chronos.json
+++ b/hashes.md/core/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Core",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-22 - 2026-04-26",
+        "changes": ["Initial UsdNode class", "Time-sampled properties", "XformOp support", "Streaming arrays", "Camera type support"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/core/.contract.json
+++ b/hashes.md/core/.contract.json
@@ -1,0 +1,32 @@
+{
+  "ForensicShard": "WebUsdFramework.Core",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "UsdNode": {
+      "type": "class",
+      "methods": [
+        "constructor(path: UsdPath, typeName: string)",
+        "setProperty(key: string, value: any, type?: string): this",
+        "getProperty(key: string): any",
+        "addChild(child: UsdNode): this",
+        "serializeToUsda(): string",
+        "updatePath(newPath: UsdPath): void"
+      ],
+      "properties": [
+        "_path: UsdPath",
+        "_typeName: string",
+        "_metadata: Map<string, any>",
+        "_children: Map<string, UsdNode>",
+        "_properties: USDProperty[]"
+      ],
+      "invariants": [
+        "Path must be valid USD path",
+        "TypeName must be valid USD prim type",
+        "Children paths are updated when parent path changes"
+      ]
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/core/.logic.md
+++ b/hashes.md/core/.logic.md
@@ -1,0 +1,43 @@
+# WebUsdFramework.Core - Business Logic
+
+## Central Abstraction
+`UsdNode` is the singular intermediary between all input parsers and USDA output formatting.
+
+## Node Lifecycle
+```
+constructor(path, typeName)
+  ↓
+setProperty / addChild
+  ↓
+serializeToUsda()
+  ↓
+String output
+```
+
+## Governance Laws
+
+### 1. Path Invariant
+All paths must match `^/[A-Za-z0-9_/]+$` pattern.
+Invalid paths throw `UsdSchemaError`.
+
+### 2. Property Type Safety
+Properties carry explicit type annotations:
+- `TOKEN` → quoted strings
+- `STRING_ARRAY` → `["a", "b"]`
+- `REL` → `<path>`
+- `FLOAT` → raw numbers
+- `RAW` → verbatim insertion
+
+### 3. Serialization Rules
+- XformOp properties go in node body
+- Array properties go in node body
+- Simple properties go in header parentheses
+- Metadata always in header
+
+### 4. Child Path Propagation
+When `updatePath()` is called, all descendants' paths are automatically updated.
+
+## Memory Management
+- Large TypedArrays use streaming (length > 1000)
+- Properties stored as array (preserves insertion order)
+- Children stored as Map (O(1) lookup)

--- a/hashes.md/core/usd-node.hash.md
+++ b/hashes.md/core/usd-node.hash.md
@@ -16,6 +16,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Governance]
 - Acts as the singular intermediary between input parser and USDA output formatting
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/core/.contract.json"
+- logic: "@root/hashes.md/core/.logic.md"
+- chronos: "@root/hashes.md/core/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/utils/logger.hash.md"

--- a/hashes.md/errors.hash.md
+++ b/hashes.md/errors.hash.md
@@ -22,6 +22,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - Inputs: message string, optional cause
 - Outputs: typed Error instances
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/.contract.json"
+- logic: "@root/hashes.md/.logic.md"
+- chronos: "@root/hashes.md/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/index.hash.md"

--- a/hashes.md/grammar/.chronos.json
+++ b/hashes.md/grammar/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Grammar",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-22 - present",
+        "changes": ["TypeScript grammar", "Effect grammar reference"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/grammar/.contract.json
+++ b/hashes.md/grammar/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Grammar",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "Language grammar definitions",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/grammar/.logic.md
+++ b/hashes.md/grammar/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Grammar - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+Language grammar definitions

--- a/hashes.md/grammar/effect.hash.md
+++ b/hashes.md/grammar/effect.hash.md
@@ -7,7 +7,14 @@ LSP_Discovery_Root: "@root/node_modules/effect/package.json"
 Grammar_Lock: "@root/hashes/grammar/effect.hash.md"
 ---
 
-/** [Project].Grammar.Effect - Linguistic DNA anchor for Effect Ecosystem */
+## @WebUsdFramework.Grammar.Effect
+
+/** WebUsdFramework.Grammar.Effect - Linguistic DNA anchor for Effect Ecosystem */
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/grammar/.contract.json"
+- logic: "@root/hashes.md/grammar/.logic.md"
+- chronos: "@root/hashes.md/grammar/.chronos.json"
 
 ## [SDK_Discovery_Map]
 /** === effect (Core Infrastructure) === */

--- a/hashes.md/grammar/typescript.hash.md
+++ b/hashes.md/grammar/typescript.hash.md
@@ -7,7 +7,14 @@ LSP_Discovery_Root: "@root/node_modules/typescript/package.json"
 Grammar_Lock: "@root/hashes/grammar/typescript.hash.md"
 ---
 
+## @WebUsdFramework.Grammar.TypeScript
+
 /** WebUsdFramework.Grammar.TypeScript - Linguistic DNA anchor for TypeScript 5.9.x */
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/grammar/.contract.json"
+- logic: "@root/hashes.md/grammar/.logic.md"
+- chronos: "@root/hashes.md/grammar/.chronos.json"
 
 ## [SDK_Discovery_Map]
 /** === Core Lib Files (70+ declarations) === */

--- a/hashes.md/index.hash.md
+++ b/hashes.md/index.hash.md
@@ -20,6 +20,35 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - Inputs: FrameworkOptions
 - Outputs: Blob (USDZ binary)
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/.contract.json"
+- logic: "@root/hashes.md/.logic.md"
+- chronos: "@root/hashes.md/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: build/index.js
+- depends_on: "@root/hashes.md/schemas/index.hash.md"
+- depends_on: "@root/hashes.md/converters/gltf/index.hash.md"
+- depends_on: "@root/hashes.md/converters/ply/ply-converter.hash.md"
+- depends_on: "@root/hashes.md/converters/obj/index.hash.md"
+- depends_on: "@root/hashes.md/converters/stl/index.hash.md"
+
+### [Module Boundaries]
+- Entry Point: Yes (Public API)
+- Barrel File: Yes
+- Internal Access: No (all internal modules hidden)
+
+### [Type Signatures]
+```typescript
+type FrameworkOptions = {
+  debug?: boolean;
+  debugOutputDir?: string;
+  upAxis?: 'Y' | 'Z';
+  metersPerUnit?: number;
+}
+
+type FrameworkInstance = {
+  convert(input: string | ArrayBuffer, config?: ConverterConfig): Promise<Blob>;
+}
+```

--- a/hashes.md/interfaces/.chronos.json
+++ b/hashes.md/interfaces/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Interfaces",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-22 - present",
+        "changes": ["Core interfaces", "Converter contracts"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/interfaces/.contract.json
+++ b/hashes.md/interfaces/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Interfaces",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "TypeScript interfaces",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/interfaces/.logic.md
+++ b/hashes.md/interfaces/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Interfaces - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+TypeScript interfaces

--- a/hashes.md/interfaces/index.hash.md
+++ b/hashes.md/interfaces/index.hash.md
@@ -17,6 +17,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - Export_Law: All interfaces re-exported from this single barrel
 - No implementation code; types-only file
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/interfaces/.contract.json"
+- logic: "@root/hashes.md/interfaces/.logic.md"
+- chronos: "@root/hashes.md/interfaces/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/index.hash.md"

--- a/hashes.md/local.map.json
+++ b/hashes.md/local.map.json
@@ -30,7 +30,9 @@
       "file_path": "@root/src/validation.ts",
       "hash_reference": "@root/hashes.md/validation.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/errors.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/errors.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/constants/index": {
@@ -107,21 +109,27 @@
       "file_path": "@root/src/schemas/obj-schemas.ts",
       "hash_reference": "@root/hashes.md/schemas/obj-schemas.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/schemas/base-schemas.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/schemas/base-schemas.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/schemas/stl-schemas": {
       "file_path": "@root/src/schemas/stl-schemas.ts",
       "hash_reference": "@root/hashes.md/schemas/stl-schemas.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/schemas/base-schemas.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/schemas/base-schemas.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/schemas/zip-writer": {
       "file_path": "@root/src/schemas/zip-writer.ts",
       "hash_reference": "@root/hashes.md/schemas/zip-writer.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/constants/zip.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/constants/zip.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/utils/index": {
@@ -222,35 +230,45 @@
       "file_path": "@root/src/converters/shared/usd-geometry-builder.ts",
       "hash_reference": "@root/hashes.md/converters/shared/usd-geometry-builder.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/core/usd-node.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/core/usd-node.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/shared/usd-material-builder": {
       "file_path": "@root/src/converters/shared/usd-material-builder.ts",
       "hash_reference": "@root/hashes.md/converters/shared/usd-material-builder.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/core/usd-node.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/core/usd-node.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/shared/usd-packaging": {
       "file_path": "@root/src/converters/shared/usd-packaging.ts",
       "hash_reference": "@root/hashes.md/converters/shared/usd-packaging.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/converters/shared/usdz-zip-writer.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdz-zip-writer.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/shared/usd-root-builder": {
       "file_path": "@root/src/converters/shared/usd-root-builder.ts",
       "hash_reference": "@root/hashes.md/converters/shared/usd-root-builder.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/core/usd-node.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/core/usd-node.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/shared/usdz-zip-writer": {
       "file_path": "@root/src/converters/shared/usdz-zip-writer.ts",
       "hash_reference": "@root/hashes.md/converters/shared/usdz-zip-writer.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/schemas/zip-writer.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/schemas/zip-writer.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/fbx/fbx-to-gltf-via-tool": {
@@ -264,7 +282,9 @@
       "file_path": "@root/src/converters/fbx/index.ts",
       "hash_reference": "@root/hashes.md/converters/fbx/index.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/converters/fbx/fbx-to-gltf-via-tool.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/converters/fbx/fbx-to-gltf-via-tool.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/gltf/gltf-converter": {
@@ -290,7 +310,9 @@
       "file_path": "@root/src/converters/gltf/index.ts",
       "hash_reference": "@root/hashes.md/converters/gltf/index.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/converters/gltf/gltf-converter.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/gltf-converter.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/gltf/extensions/extension-factory": {
@@ -304,7 +326,19 @@
       "file_path": "@root/src/converters/gltf/extensions/extension-processor.ts",
       "hash_reference": "@root/hashes.md/converters/gltf/extensions/extension-processor.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/converters/gltf/extensions/extension-factory.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-factory.hash.md"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/index": {
+      "file_path": "@root/src/converters/gltf/extensions/index.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/index.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor",
+        "@root/hashes.md/converters/gltf/extensions/extension-factory"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/gltf/extensions/instancing-processor": {
@@ -342,14 +376,18 @@
       "file_path": "@root/src/converters/gltf/helpers/animation-processor-factory.ts",
       "hash_reference": "@root/hashes.md/converters/gltf/helpers/animation-processor-factory.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/converters/gltf/helpers/animation-processor.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/helpers/animation-processor.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/gltf/helpers/geometry-processor": {
       "file_path": "@root/src/converters/gltf/helpers/geometry-processor.ts",
       "hash_reference": "@root/hashes.md/converters/gltf/helpers/geometry-processor.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/converters/shared/usd-geometry-builder.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usd-geometry-builder.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/gltf/helpers/gltf-transform-helpers": {
@@ -373,7 +411,9 @@
       "file_path": "@root/src/converters/gltf/helpers/usd-hierarchy-builder.ts",
       "hash_reference": "@root/hashes.md/converters/gltf/helpers/usd-hierarchy-builder.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/core/usd-node.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/core/usd-node.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/gltf/helpers/vertex-color-baker": {
@@ -404,14 +444,18 @@
       "file_path": "@root/src/converters/obj/obj-parser.ts",
       "hash_reference": "@root/hashes.md/converters/obj/obj-parser.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/converters/obj/obj-mesh-parser.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/converters/obj/obj-mesh-parser.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/obj/helpers/obj-to-usd-adapter": {
       "file_path": "@root/src/converters/obj/helpers/obj-to-usd-adapter.ts",
       "hash_reference": "@root/hashes.md/converters/obj/helpers/obj-to-usd-adapter.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
-      "dependencies": ["@root/hashes.md/converters/shared/usd-geometry-builder.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usd-geometry-builder.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "src/converters/stl/stl-converter": {
@@ -442,7 +486,9 @@
       "file_path": "@root/scripts/inspect.cjs",
       "hash_reference": "@root/hashes.md/scripts/inspect.hash.md",
       "grammar_ref": "@root/hashes.md/grammar/javascript.hash.md",
-      "dependencies": ["@root/hashes.md/scripts/convert.hash.md"],
+      "dependencies": [
+        "@root/hashes.md/scripts/convert.hash.md"
+      ],
       "fidelity_level": "Active"
     },
     "scripts/validate-usdz": {
@@ -454,6 +500,900 @@
         "@root/hashes.md/scripts/inspect.hash.md"
       ],
       "fidelity_level": "Active"
+    },
+    "src/converters/ply/index": {
+      "file_path": "@root/src/converters/ply/index.ts",
+      "hash_reference": "@root/hashes.md/converters/ply/index.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/ply/ply-converter"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/ply/mesh-decimator": {
+      "file_path": "@root/src/converters/ply/mesh-decimator.ts",
+      "hash_reference": "@root/hashes.md/converters/ply/mesh-decimator.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "src/converters/ply/ply-converter": {
+      "file_path": "@root/src/converters/ply/ply-converter.ts",
+      "hash_reference": "@root/hashes.md/converters/ply/ply-converter.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/schemas",
+        "@root/hashes.md/utils",
+        "@root/hashes.md/converters/ply/ply-parser",
+        "@root/hashes.md/converters/ply/mesh-decimator",
+        "@root/hashes.md/converters/shared/usd-root-builder",
+        "@root/hashes.md/converters/shared/usd-packaging",
+        "@root/hashes.md/converters/shared/debug-writer",
+        "@root/hashes.md/core/usd-node",
+        "@root/hashes.md/constants/usd"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/ply/ply-parser": {
+      "file_path": "@root/src/converters/ply/ply-parser.ts",
+      "hash_reference": "@root/hashes.md/converters/ply/ply-parser.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/array-values": {
+      "file_path": "@root/src/converters/shared/usdc/array-values.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/array-values.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/lz4-block",
+        "@root/hashes.md/converters/shared/usdc/value-rep"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/fields-section": {
+      "file_path": "@root/src/converters/shared/usdc/fields-section.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/fields-section.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/integer-coding"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/fieldsets-section": {
+      "file_path": "@root/src/converters/shared/usdc/fieldsets-section.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/fieldsets-section.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/integer-coding"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/index": {
+      "file_path": "@root/src/converters/shared/usdc/index.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/index.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/tokens-section",
+        "@root/hashes.md/converters/shared/usdc/strings-section",
+        "@root/hashes.md/converters/shared/usdc/fields-section",
+        "@root/hashes.md/converters/shared/usdc/fieldsets-section",
+        "@root/hashes.md/converters/shared/usdc/paths-section",
+        "@root/hashes.md/converters/shared/usdc/specs-section",
+        "@root/hashes.md/converters/shared/usdc/array-values",
+        "@root/hashes.md/converters/shared/usdc/value-rep",
+        "@root/hashes.md/converters/shared/usdc/layer-builder",
+        "@root/hashes.md/converters/shared/usdc/lz4-block",
+        "@root/hashes.md/converters/shared/usdc/integer-coding"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/integer-coding": {
+      "file_path": "@root/src/converters/shared/usdc/integer-coding.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/integer-coding.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/layer-builder": {
+      "file_path": "@root/src/converters/shared/usdc/layer-builder.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/layer-builder.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc-writer",
+        "@root/hashes.md/converters/shared/usdc/tokens-section",
+        "@root/hashes.md/converters/shared/usdc/strings-section",
+        "@root/hashes.md/converters/shared/usdc/fields-section",
+        "@root/hashes.md/converters/shared/usdc/fieldsets-section",
+        "@root/hashes.md/converters/shared/usdc/paths-section",
+        "@root/hashes.md/converters/shared/usdc/specs-section",
+        "@root/hashes.md/converters/shared/usdc/array-values",
+        "@root/hashes.md/converters/shared/usdc/listop-values",
+        "@root/hashes.md/converters/shared/usdc/value-rep"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/listop-values": {
+      "file_path": "@root/src/converters/shared/usdc/listop-values.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/listop-values.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/value-rep",
+        "@root/hashes.md/converters/shared/usdc/array-values"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/lz4-block": {
+      "file_path": "@root/src/converters/shared/usdc/lz4-block.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/lz4-block.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/paths-section": {
+      "file_path": "@root/src/converters/shared/usdc/paths-section.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/paths-section.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/integer-coding"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/property-parser": {
+      "file_path": "@root/src/converters/shared/usdc/property-parser.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/property-parser.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/value-rep"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/specs-section": {
+      "file_path": "@root/src/converters/shared/usdc/specs-section.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/specs-section.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/integer-coding",
+        "@root/hashes.md/converters/shared/usdc/value-rep"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/strings-section": {
+      "file_path": "@root/src/converters/shared/usdc/strings-section.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/strings-section.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/tokens-section": {
+      "file_path": "@root/src/converters/shared/usdc/tokens-section.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/tokens-section.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/lz4-block"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/usd-node-adapter": {
+      "file_path": "@root/src/converters/shared/usdc/usd-node-adapter.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/usd-node-adapter.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/core/usd-node",
+        "@root/hashes.md/converters/shared/usdc/layer-builder",
+        "@root/hashes.md/converters/shared/usdc/property-parser",
+        "@root/hashes.md/converters/shared/usdc/value-rep",
+        "@root/hashes.md/converters/shared/usdc/usda-value-parser"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/usda-value-parser": {
+      "file_path": "@root/src/converters/shared/usdc/usda-value-parser.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/usda-value-parser.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc/value-rep": {
+      "file_path": "@root/src/converters/shared/usdc/value-rep.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc/value-rep.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-anisotropy-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-anisotropy-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-anisotropy-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor",
+        "@root/hashes.md/converters/shared/usd-material-builder",
+        "@root/hashes.md/converters/gltf/extensions/processors/texture-utils"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-clearcoat-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-clearcoat-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-clearcoat-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor",
+        "@root/hashes.md/converters/shared/usd-material-builder",
+        "@root/hashes.md/converters/gltf/extensions/processors/texture-utils"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-diffuse-transmission-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-diffuse-transmission-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-diffuse-transmission-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor",
+        "@root/hashes.md/converters/shared/usd-material-builder",
+        "@root/hashes.md/converters/gltf/extensions/processors/texture-utils"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-dispersion-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-dispersion-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-dispersion-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-emissive-strength-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-emissive-strength-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-emissive-strength-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-ior-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-ior-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-ior-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-iridescence-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-iridescence-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-iridescence-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor",
+        "@root/hashes.md/converters/shared/usd-material-builder",
+        "@root/hashes.md/converters/gltf/extensions/processors/texture-utils"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-sheen-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-sheen-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-sheen-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor",
+        "@root/hashes.md/converters/shared/usd-material-builder",
+        "@root/hashes.md/converters/gltf/extensions/processors/texture-utils"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-specular-glossiness-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-specular-glossiness-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-specular-glossiness-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor",
+        "@root/hashes.md/converters/shared/usd-material-builder",
+        "@root/hashes.md/converters/gltf/extensions/processors/texture-utils"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-specular-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-specular-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-specular-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor",
+        "@root/hashes.md/converters/shared/usd-material-builder",
+        "@root/hashes.md/converters/gltf/extensions/processors/texture-utils"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-transmission-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-transmission-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-transmission-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor",
+        "@root/hashes.md/converters/shared/usd-material-builder",
+        "@root/hashes.md/converters/gltf/extensions/processors/texture-utils"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-unlit-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-unlit-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-unlit-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/pbr-volume-processor": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/pbr-volume-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/pbr-volume-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf/extensions/extension-processor",
+        "@root/hashes.md/converters/shared/usd-material-builder",
+        "@root/hashes.md/converters/gltf/extensions/processors/texture-utils"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/extensions/processors/texture-utils": {
+      "file_path": "@root/src/converters/gltf/extensions/processors/texture-utils.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/extensions/processors/texture-utils.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/helpers/processors/morph-target-animation-processor": {
+      "file_path": "@root/src/converters/gltf/helpers/processors/morph-target-animation-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/helpers/processors/morph-target-animation-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/core/usd-node",
+        "@root/hashes.md/utils",
+        "@root/hashes.md/constants",
+        "@root/hashes.md/converters/gltf/helpers/animation-processor-factory",
+        "@root/hashes.md/utils/time-code-converter",
+        "@root/hashes.md/utils/usd-formatter"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/helpers/processors/node-animation-processor": {
+      "file_path": "@root/src/converters/gltf/helpers/processors/node-animation-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/helpers/processors/node-animation-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/core/usd-node",
+        "@root/hashes.md/utils",
+        "@root/hashes.md/constants",
+        "@root/hashes.md/converters/gltf/helpers/animation-processor-factory",
+        "@root/hashes.md/utils/usd-formatter"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/gltf/helpers/processors/skeleton-animation-processor": {
+      "file_path": "@root/src/converters/gltf/helpers/processors/skeleton-animation-processor.ts",
+      "hash_reference": "@root/hashes.md/converters/gltf/helpers/processors/skeleton-animation-processor.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/core/usd-node",
+        "@root/hashes.md/utils",
+        "@root/hashes.md/utils/usd-formatter",
+        "@root/hashes.md/utils/api-schema-builder",
+        "@root/hashes.md/converters/gltf/helpers/skeleton-processor",
+        "@root/hashes.md/converters/gltf/helpers/animation-processor-factory",
+        "@root/hashes.md/constants"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/cli/constants/constants": {
+      "file_path": "@root/src/cli/constants/constants.ts",
+      "hash_reference": "@root/hashes.md/cli/constants/constants.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "src/cli/constants/index": {
+      "file_path": "@root/src/cli/constants/index.ts",
+      "hash_reference": "@root/hashes.md/cli/constants/index.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/cli/constants/constants"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/cli/errors/errors": {
+      "file_path": "@root/src/cli/errors/errors.ts",
+      "hash_reference": "@root/hashes.md/cli/errors/errors.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "src/cli/errors/index": {
+      "file_path": "@root/src/cli/errors/index.ts",
+      "hash_reference": "@root/hashes.md/cli/errors/index.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/cli/errors/errors"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/cli/index": {
+      "file_path": "@root/src/cli/index.ts",
+      "hash_reference": "@root/hashes.md/cli/index.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/cli/services/CliConfig",
+        "@root/hashes.md/cli/services/CliLogger",
+        "@root/hashes.md/cli/services/Converter",
+        "@root/hashes.md/cli/errors",
+        "@root/hashes.md/cli/constants"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/cli/main": {
+      "file_path": "@root/src/cli/main.ts",
+      "hash_reference": "@root/hashes.md/cli/main.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/cli/services/CliConfig",
+        "@root/hashes.md/cli/services/CliLogger",
+        "@root/hashes.md/cli/services/Converter",
+        "@root/hashes.md/cli/errors",
+        "@root/hashes.md/cli/constants"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/cli/services/CliConfig": {
+      "file_path": "@root/src/cli/services/CliConfig.ts",
+      "hash_reference": "@root/hashes.md/cli/services/CliConfig.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/cli/errors",
+        "@root/hashes.md/cli/constants"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/cli/services/CliLogger": {
+      "file_path": "@root/src/cli/services/CliLogger.ts",
+      "hash_reference": "@root/hashes.md/cli/services/CliLogger.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/cli/services/CliConfig"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/cli/services/Converter": {
+      "file_path": "@root/src/cli/services/Converter.ts",
+      "hash_reference": "@root/hashes.md/cli/services/Converter.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/cli/services/CliConfig",
+        "@root/hashes.md/cli/services/CliLogger",
+        "@root/hashes.md/cli/errors",
+        "@root/hashes.md/index"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/converter-streaming.test": {
+      "file_path": "@root/src/__tests__/converter-streaming.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/converter-streaming.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf",
+        "@root/hashes.md/converters/ply/ply-converter",
+        "@root/hashes.md/converters/obj/obj-converter",
+        "@root/hashes.md/converters/stl/stl-converter"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/converters.test": {
+      "file_path": "@root/src/__tests__/converters.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/converters.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/gltf"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/ply-converter.test": {
+      "file_path": "@root/src/__tests__/ply-converter.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/ply-converter.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/ply/ply-parser",
+        "@root/hashes.md/converters/ply/ply-converter"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usd-node.test": {
+      "file_path": "@root/src/__tests__/usd-node.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usd-node.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/core/usd-node"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usd-packaging-stream.test": {
+      "file_path": "@root/src/__tests__/usd-packaging-stream.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usd-packaging-stream.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usd-packaging"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-array-values.test": {
+      "file_path": "@root/src/__tests__/usdc-array-values.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-array-values.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/array-values",
+        "@root/hashes.md/converters/shared/usdc/value-rep"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-fields-section.test": {
+      "file_path": "@root/src/__tests__/usdc-fields-section.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-fields-section.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/fields-section",
+        "@root/hashes.md/converters/shared/usdc/value-rep"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-fieldsets-section.test": {
+      "file_path": "@root/src/__tests__/usdc-fieldsets-section.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-fieldsets-section.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/fieldsets-section"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-integer-coding.test": {
+      "file_path": "@root/src/__tests__/usdc-integer-coding.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-integer-coding.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/integer-coding"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-layer-builder.test": {
+      "file_path": "@root/src/__tests__/usdc-layer-builder.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-layer-builder.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/layer-builder",
+        "@root/hashes.md/converters/shared/usdc-writer",
+        "@root/hashes.md/converters/shared/usdc/tokens-section",
+        "@root/hashes.md/converters/shared/usdc/fields-section",
+        "@root/hashes.md/converters/shared/usdc/fieldsets-section",
+        "@root/hashes.md/converters/shared/usdc/paths-section",
+        "@root/hashes.md/converters/shared/usdc/specs-section",
+        "@root/hashes.md/converters/shared/usdc/value-rep"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-listop-values.test": {
+      "file_path": "@root/src/__tests__/usdc-listop-values.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-listop-values.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/listop-values",
+        "@root/hashes.md/converters/shared/usdc/value-rep"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-lz4-block.test": {
+      "file_path": "@root/src/__tests__/usdc-lz4-block.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-lz4-block.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/lz4-block"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-package-integration.test": {
+      "file_path": "@root/src/__tests__/usdc-package-integration.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-package-integration.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/core/usd-node",
+        "@root/hashes.md/converters/shared/usd-packaging"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-paths-section.test": {
+      "file_path": "@root/src/__tests__/usdc-paths-section.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-paths-section.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/paths-section"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-ply-end-to-end.test": {
+      "file_path": "@root/src/__tests__/usdc-ply-end-to-end.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-ply-end-to-end.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/ply/ply-converter"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-property-parser.test": {
+      "file_path": "@root/src/__tests__/usdc-property-parser.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-property-parser.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/property-parser",
+        "@root/hashes.md/converters/shared/usdc/value-rep"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-specs-section.test": {
+      "file_path": "@root/src/__tests__/usdc-specs-section.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-specs-section.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/specs-section",
+        "@root/hashes.md/converters/shared/usdc/value-rep"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-strings-section.test": {
+      "file_path": "@root/src/__tests__/usdc-strings-section.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-strings-section.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/strings-section"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-tokens-section.test": {
+      "file_path": "@root/src/__tests__/usdc-tokens-section.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-tokens-section.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/tokens-section"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-usd-node-adapter.test": {
+      "file_path": "@root/src/__tests__/usdc-usd-node-adapter.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-usd-node-adapter.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/core/usd-node",
+        "@root/hashes.md/converters/shared/usdc/usd-node-adapter",
+        "@root/hashes.md/converters/shared/usdc/layer-builder",
+        "@root/hashes.md/converters/shared/usdc/tokens-section",
+        "@root/hashes.md/converters/shared/usdc/specs-section",
+        "@root/hashes.md/converters/shared/usdc/fields-section",
+        "@root/hashes.md/converters/shared/usdc-writer",
+        "@root/hashes.md/converters/shared/usdc/value-rep"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-usda-value-parser.test": {
+      "file_path": "@root/src/__tests__/usdc-usda-value-parser.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-usda-value-parser.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/usda-value-parser"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-value-rep.test": {
+      "file_path": "@root/src/__tests__/usdc-value-rep.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-value-rep.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc/value-rep"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdc-writer.test": {
+      "file_path": "@root/src/__tests__/usdc-writer.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdc-writer.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdc-writer"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/__tests__/usdz-stream-writer.test": {
+      "file_path": "@root/src/__tests__/usdz-stream-writer.test.ts",
+      "hash_reference": "@root/hashes.md/__tests__/usdz-stream-writer.test.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/shared/usdz-zip-writer",
+        "@root/hashes.md/converters/shared/usdz-stream-writer"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdc-writer": {
+      "file_path": "@root/src/converters/shared/usdc-writer.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdc-writer.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "src/converters/shared/usdz-stream-writer": {
+      "file_path": "@root/src/converters/shared/usdz-stream-writer.ts",
+      "hash_reference": "@root/hashes.md/converters/shared/usdz-stream-writer.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/constants",
+        "@root/hashes.md/schemas/zip-writer"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/schemas/ply-schemas": {
+      "file_path": "@root/src/schemas/ply-schemas.ts",
+      "hash_reference": "@root/hashes.md/schemas/ply-schemas.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/schemas/base-schemas"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/obj/index": {
+      "file_path": "@root/src/converters/obj/index.ts",
+      "hash_reference": "@root/hashes.md/converters/obj/index.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/obj/obj-converter"
+      ],
+      "fidelity_level": "Active"
+    },
+    "src/converters/stl/index": {
+      "file_path": "@root/src/converters/stl/index.ts",
+      "hash_reference": "@root/hashes.md/converters/stl/index.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [
+        "@root/hashes.md/converters/stl/stl-converter"
+      ],
+      "fidelity_level": "Active"
+    },
+    "grammar/typescript": {
+      "file_path": "@root/hashes.md/grammar/typescript.hash.md",
+      "hash_reference": "@root/hashes.md/grammar/typescript.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/typescript.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    },
+    "grammar/effect": {
+      "file_path": "@root/hashes.md/grammar/effect.hash.md",
+      "hash_reference": "@root/hashes.md/grammar/effect.hash.md",
+      "grammar_ref": "@root/hashes.md/grammar/effect.hash.md",
+      "dependencies": [],
+      "fidelity_level": "Active"
+    }
+  },
+  "forensic_shards": {
+    "root": {
+      "contract": "@root/hashes.md/.contract.json",
+      "logic": "@root/hashes.md/.logic.md",
+      "chronos": "@root/hashes.md/.chronos.json"
+    },
+    "constants": {
+      "contract": "@root/hashes.md/constants/.contract.json",
+      "logic": "@root/hashes.md/constants/.logic.md",
+      "chronos": "@root/hashes.md/constants/.chronos.json"
+    },
+    "core": {
+      "contract": "@root/hashes.md/core/.contract.json",
+      "logic": "@root/hashes.md/core/.logic.md",
+      "chronos": "@root/hashes.md/core/.chronos.json"
+    },
+    "converters": {
+      "contract": "@root/hashes.md/converters/.contract.json",
+      "logic": "@root/hashes.md/converters/.logic.md",
+      "chronos": "@root/hashes.md/converters/.chronos.json"
+    },
+    "cli": {
+      "contract": "@root/hashes.md/cli/.contract.json",
+      "logic": "@root/hashes.md/cli/.logic.md",
+      "chronos": "@root/hashes.md/cli/.chronos.json"
+    },
+    "grammar": {
+      "contract": "@root/hashes.md/grammar/.contract.json",
+      "logic": "@root/hashes.md/grammar/.logic.md",
+      "chronos": "@root/hashes.md/grammar/.chronos.json"
+    },
+    "interfaces": {
+      "contract": "@root/hashes.md/interfaces/.contract.json",
+      "logic": "@root/hashes.md/interfaces/.logic.md",
+      "chronos": "@root/hashes.md/interfaces/.chronos.json"
+    },
+    "schemas": {
+      "contract": "@root/hashes.md/schemas/.contract.json",
+      "logic": "@root/hashes.md/schemas/.logic.md",
+      "chronos": "@root/hashes.md/schemas/.chronos.json"
+    },
+    "scripts": {
+      "contract": "@root/hashes.md/scripts/.contract.json",
+      "logic": "@root/hashes.md/scripts/.logic.md",
+      "chronos": "@root/hashes.md/scripts/.chronos.json"
+    },
+    "utils": {
+      "contract": "@root/hashes.md/utils/.contract.json",
+      "logic": "@root/hashes.md/utils/.logic.md",
+      "chronos": "@root/hashes.md/utils/.chronos.json"
+    },
+    "tests": {
+      "contract": "@root/hashes.md/__tests__/.contract.json",
+      "logic": "@root/hashes.md/__tests__/.logic.md",
+      "chronos": "@root/hashes.md/__tests__/.chronos.json"
+    },
+    "converters_fbx": {
+      "contract": "@root/hashes.md/converters/fbx/.contract.json",
+      "logic": "@root/hashes.md/converters/fbx/.logic.md",
+      "chronos": "@root/hashes.md/converters/fbx/.chronos.json"
+    },
+    "converters_gltf_extensions": {
+      "contract": "@root/hashes.md/converters/gltf/extensions/.contract.json",
+      "logic": "@root/hashes.md/converters/gltf/extensions/.logic.md",
+      "chronos": "@root/hashes.md/converters/gltf/extensions/.chronos.json"
+    },
+    "converters_gltf_extensions_processors": {
+      "contract": "@root/hashes.md/converters/gltf/extensions/processors/.contract.json",
+      "logic": "@root/hashes.md/converters/gltf/extensions/processors/.logic.md",
+      "chronos": "@root/hashes.md/converters/gltf/extensions/processors/.chronos.json"
+    },
+    "converters_gltf_helpers": {
+      "contract": "@root/hashes.md/converters/gltf/helpers/.contract.json",
+      "logic": "@root/hashes.md/converters/gltf/helpers/.logic.md",
+      "chronos": "@root/hashes.md/converters/gltf/helpers/.chronos.json"
+    },
+    "converters_gltf_helpers_processors": {
+      "contract": "@root/hashes.md/converters/gltf/helpers/processors/.contract.json",
+      "logic": "@root/hashes.md/converters/gltf/helpers/processors/.logic.md",
+      "chronos": "@root/hashes.md/converters/gltf/helpers/processors/.chronos.json"
+    },
+    "converters_obj": {
+      "contract": "@root/hashes.md/converters/obj/.contract.json",
+      "logic": "@root/hashes.md/converters/obj/.logic.md",
+      "chronos": "@root/hashes.md/converters/obj/.chronos.json"
+    },
+    "converters_obj_helpers": {
+      "contract": "@root/hashes.md/converters/obj/helpers/.contract.json",
+      "logic": "@root/hashes.md/converters/obj/helpers/.logic.md",
+      "chronos": "@root/hashes.md/converters/obj/helpers/.chronos.json"
+    },
+    "converters_ply": {
+      "contract": "@root/hashes.md/converters/ply/.contract.json",
+      "logic": "@root/hashes.md/converters/ply/.logic.md",
+      "chronos": "@root/hashes.md/converters/ply/.chronos.json"
+    },
+    "converters_shared_usdc": {
+      "contract": "@root/hashes.md/converters/shared/usdc/.contract.json",
+      "logic": "@root/hashes.md/converters/shared/usdc/.logic.md",
+      "chronos": "@root/hashes.md/converters/shared/usdc/.chronos.json"
+    },
+    "converters_stl": {
+      "contract": "@root/hashes.md/converters/stl/.contract.json",
+      "logic": "@root/hashes.md/converters/stl/.logic.md",
+      "chronos": "@root/hashes.md/converters/stl/.chronos.json"
+    },
+    "cli_constants": {
+      "contract": "@root/hashes.md/cli/constants/.contract.json",
+      "logic": "@root/hashes.md/cli/constants/.logic.md",
+      "chronos": "@root/hashes.md/cli/constants/.chronos.json"
+    },
+    "cli_errors": {
+      "contract": "@root/hashes.md/cli/errors/.contract.json",
+      "logic": "@root/hashes.md/cli/errors/.logic.md",
+      "chronos": "@root/hashes.md/cli/errors/.chronos.json"
+    },
+    "cli_services": {
+      "contract": "@root/hashes.md/cli/services/.contract.json",
+      "logic": "@root/hashes.md/cli/services/.logic.md",
+      "chronos": "@root/hashes.md/cli/services/.chronos.json"
     }
   }
 }

--- a/hashes.md/schemas/.chronos.json
+++ b/hashes.md/schemas/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Schemas",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-22 - 2026-04-18",
+        "changes": ["Base schemas", "OBJ schemas", "STL schemas", "PLY schemas", "ZIP writer schemas"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/schemas/.contract.json
+++ b/hashes.md/schemas/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Schemas",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "USD schema builders",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/schemas/.logic.md
+++ b/hashes.md/schemas/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Schemas - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+USD schema builders

--- a/hashes.md/schemas/base-schemas.hash.md
+++ b/hashes.md/schemas/base-schemas.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `buildStageHeader(meta: StageMeta): string`
 - `buildPrimBlock(type: string, name: string, body: string): string`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/schemas/.contract.json"
+- logic: "@root/hashes.md/schemas/.logic.md"
+- chronos: "@root/hashes.md/schemas/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/schemas/obj-schemas.hash.md"

--- a/hashes.md/schemas/index.hash.md
+++ b/hashes.md/schemas/index.hash.md
@@ -14,5 +14,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Governance]
 - Export_Law: Single barrel; all schema builders exported from here
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/schemas/.contract.json"
+- logic: "@root/hashes.md/schemas/.logic.md"
+- chronos: "@root/hashes.md/schemas/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/schemas/obj-schemas.hash.md
+++ b/hashes.md/schemas/obj-schemas.hash.md
@@ -12,6 +12,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `buildObjMeshPrim(data: ObjMeshData): string`
 - `buildObjMaterialPrim(data: ObjMatData): string`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/schemas/.contract.json"
+- logic: "@root/hashes.md/schemas/.logic.md"
+- chronos: "@root/hashes.md/schemas/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/schemas/base-schemas.hash.md"

--- a/hashes.md/schemas/ply-schemas.hash.md
+++ b/hashes.md/schemas/ply-schemas.hash.md
@@ -1,0 +1,20 @@
+---
+State_ID: BigInt(0x1)
+Git_SHA: HEAD_SHA
+Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
+---
+
+## @WebUsdFramework.Schemas.PlySchemas
+
+/** WebUsdFramework.Schemas.PlySchemas - WebUsdFramework.Schemas.PlySchemas - PLY-specific converter configuration */
+
+### [Signatures]
+- `PlyConverterConfigSchema()`
+
+### [Forensic Metadata]
+- contract: "@root/hashes.md/schemas/.contract.json"
+- logic: "@root/hashes.md/schemas/.logic.md"
+- chronos: "@root/hashes.md/schemas/.chronos.json"
+
+### [Linkage]
+- grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/schemas/stl-schemas.hash.md
+++ b/hashes.md/schemas/stl-schemas.hash.md
@@ -11,6 +11,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - `buildStlMeshPrim(data: StlMeshData): string`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/schemas/.contract.json"
+- logic: "@root/hashes.md/schemas/.logic.md"
+- chronos: "@root/hashes.md/schemas/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/schemas/base-schemas.hash.md"

--- a/hashes.md/schemas/zip-writer.hash.md
+++ b/hashes.md/schemas/zip-writer.hash.md
@@ -16,6 +16,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Governance]
 - Must maintain 64-byte alignment for uncompressed USDA and asset payload data
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/schemas/.contract.json"
+- logic: "@root/hashes.md/schemas/.logic.md"
+- chronos: "@root/hashes.md/schemas/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/constants/zip.hash.md"

--- a/hashes.md/scripts/.chronos.json
+++ b/hashes.md/scripts/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Scripts",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-22 - present",
+        "changes": ["Convert script", "Inspect script", "Validation script"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/scripts/.contract.json
+++ b/hashes.md/scripts/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Scripts",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "Build and test scripts",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/scripts/.logic.md
+++ b/hashes.md/scripts/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Scripts - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+Build and test scripts

--- a/hashes.md/scripts/convert.hash.md
+++ b/hashes.md/scripts/convert.hash.md
@@ -11,6 +11,11 @@ Grammar_Lock: "@root/hashes.md/grammar/javascript.hash.md"
 ### [Signatures]
 - `$ node scripts/convert.cjs <input> [out-dir]`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/scripts/.contract.json"
+- logic: "@root/hashes.md/scripts/.logic.md"
+- chronos: "@root/hashes.md/scripts/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/javascript.hash.md"
 - downstream: "@root/hashes.md/scripts/validate-usdz.hash.md"

--- a/hashes.md/scripts/inspect.hash.md
+++ b/hashes.md/scripts/inspect.hash.md
@@ -11,6 +11,11 @@ Grammar_Lock: "@root/hashes.md/grammar/javascript.hash.md"
 ### [Signatures]
 - `$ node scripts/inspect.cjs <source> <outputUsda>`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/scripts/.contract.json"
+- logic: "@root/hashes.md/scripts/.logic.md"
+- chronos: "@root/hashes.md/scripts/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/javascript.hash.md"
 - depends_on: "@root/hashes.md/scripts/convert.hash.md"

--- a/hashes.md/scripts/validate-usdz.hash.md
+++ b/hashes.md/scripts/validate-usdz.hash.md
@@ -11,6 +11,11 @@ Grammar_Lock: "@root/hashes.md/grammar/bash.hash.md"
 ### [Signatures]
 - `$ scripts/validate-usdz.sh [input-model] [out-dir]`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/scripts/.contract.json"
+- logic: "@root/hashes.md/scripts/.logic.md"
+- chronos: "@root/hashes.md/scripts/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/bash.hash.md"
 - depends_on: "@root/hashes.md/scripts/convert.hash.md"

--- a/hashes.md/types.hash.md
+++ b/hashes.md/types.hash.md
@@ -19,5 +19,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - Inputs: none
 - Outputs: TypeScript type aliases
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/.contract.json"
+- logic: "@root/hashes.md/.logic.md"
+- chronos: "@root/hashes.md/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/utils/.chronos.json
+++ b/hashes.md/utils/.chronos.json
@@ -1,0 +1,17 @@
+{
+  "ForensicShard": "WebUsdFramework.Utils",
+  "ShardType": "TEMPORAL_METADATA",
+  "SearchComplexity": "O(1)",
+  "Timeline": {
+    "created": "2025-10-22T00:00:00Z",
+    "epochs": [
+      {
+        "epoch": 1,
+        "range": "2025-10-22 - 2025-11-13",
+        "changes": ["Logger", "Encoding", "Matrix utils", "Transform utils", "Time code converter", "USD formatter"]
+      }
+    ]
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/utils/.contract.json
+++ b/hashes.md/utils/.contract.json
@@ -1,0 +1,13 @@
+{
+  "ForensicShard": "WebUsdFramework.Utils",
+  "ShardType": "API_CONTRACT",
+  "SearchComplexity": "O(1)",
+  "Contracts": {
+    "module": {
+      "description": "Utility functions",
+      "exports": "See .hash.md files in this directory"
+    }
+  },
+  "VersionLock": "HEAD_SHA",
+  "StateHash": "0x1"
+}

--- a/hashes.md/utils/.logic.md
+++ b/hashes.md/utils/.logic.md
@@ -1,0 +1,15 @@
+# WebUsdFramework.Utils - Business Logic
+
+## Forensic Sharding
+- `.contract.json` → API contracts
+- `.logic.md` → Business rules
+- `.chronos.json` → Temporal metadata
+
+## Governance
+All modules in this namespace follow:
+- Type-safe exports
+- Error propagation via FrameworkError
+- No circular dependencies
+
+## Description
+Utility functions

--- a/hashes.md/utils/api-schema-builder.hash.md
+++ b/hashes.md/utils/api-schema-builder.hash.md
@@ -12,5 +12,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `buildMaterialBindingAPI(materialPath: string): string`
 - `buildSkelBindingAPI(skeletonPath: string, bindTransforms: number[]): string`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/utils/.contract.json"
+- logic: "@root/hashes.md/utils/.logic.md"
+- chronos: "@root/hashes.md/utils/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/utils/encoding.hash.md
+++ b/hashes.md/utils/encoding.hash.md
@@ -12,5 +12,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `utf8ToBytes(str: string): Uint8Array`
 - `bytesToUtf8(bytes: Uint8Array): string`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/utils/.contract.json"
+- logic: "@root/hashes.md/utils/.logic.md"
+- chronos: "@root/hashes.md/utils/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/utils/file-utils.hash.md
+++ b/hashes.md/utils/file-utils.hash.md
@@ -12,5 +12,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `getExt(filename: string): string`
 - `resolvePath(base: string, relative: string): string`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/utils/.contract.json"
+- logic: "@root/hashes.md/utils/.logic.md"
+- chronos: "@root/hashes.md/utils/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/utils/index.hash.md
+++ b/hashes.md/utils/index.hash.md
@@ -14,5 +14,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Governance]
 - Export_Law: Single internal barrel for utils
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/utils/.contract.json"
+- logic: "@root/hashes.md/utils/.logic.md"
+- chronos: "@root/hashes.md/utils/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/utils/logger.hash.md
+++ b/hashes.md/utils/logger.hash.md
@@ -17,6 +17,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Governance]
 - Debug tracing only active when config.debug is true
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/utils/.contract.json"
+- logic: "@root/hashes.md/utils/.logic.md"
+- chronos: "@root/hashes.md/utils/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/core/usd-node.hash.md"

--- a/hashes.md/utils/matrix-utils.hash.md
+++ b/hashes.md/utils/matrix-utils.hash.md
@@ -12,5 +12,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `multiplyMatrix(a: number[], b: number[]): number[]`
 - `invertMatrix(m: number[]): number[]`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/utils/.contract.json"
+- logic: "@root/hashes.md/utils/.logic.md"
+- chronos: "@root/hashes.md/utils/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/utils/name-utils.hash.md
+++ b/hashes.md/utils/name-utils.hash.md
@@ -12,5 +12,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `sanitizeName(name: string): string`
 - `makeUnique(name: string, set: Set<string>): string`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/utils/.contract.json"
+- logic: "@root/hashes.md/utils/.logic.md"
+- chronos: "@root/hashes.md/utils/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/utils/property-normalizer.hash.md
+++ b/hashes.md/utils/property-normalizer.hash.md
@@ -12,5 +12,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - `normalizeVector3(v: number[]): string`
 - `normalizeColor3(c: number[]): string`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/utils/.contract.json"
+- logic: "@root/hashes.md/utils/.logic.md"
+- chronos: "@root/hashes.md/utils/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/utils/time-code-converter.hash.md
+++ b/hashes.md/utils/time-code-converter.hash.md
@@ -11,6 +11,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - `secondsToTimeCode(seconds: number): number`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/utils/.contract.json"
+- logic: "@root/hashes.md/utils/.logic.md"
+- chronos: "@root/hashes.md/utils/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - downstream: "@root/hashes.md/converters/gltf/helpers/animation-processor.hash.md"

--- a/hashes.md/utils/transform-utils.hash.md
+++ b/hashes.md/utils/transform-utils.hash.md
@@ -11,5 +11,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - `decomposeTRS(matrix: number[]): { t: number[], r: number[], s: number[] }`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/utils/.contract.json"
+- logic: "@root/hashes.md/utils/.logic.md"
+- chronos: "@root/hashes.md/utils/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/utils/usd-formatter.hash.md
+++ b/hashes.md/utils/usd-formatter.hash.md
@@ -11,5 +11,10 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 ### [Signatures]
 - `formatUsda(primTree: UsdNode): string`
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/utils/.contract.json"
+- logic: "@root/hashes.md/utils/.logic.md"
+- chronos: "@root/hashes.md/utils/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"

--- a/hashes.md/validation.hash.md
+++ b/hashes.md/validation.hash.md
@@ -19,6 +19,11 @@ Grammar_Lock: "@root/hashes.md/grammar/typescript.hash.md"
 - Inputs: raw user-supplied strings and option objects
 - Outputs: validated typed values or ValidationError
 
+### [Forensic Metadata]
+- contract: "@root/hashes.md/.contract.json"
+- logic: "@root/hashes.md/.logic.md"
+- chronos: "@root/hashes.md/.chronos.json"
+
 ### [Linkage]
 - grammar_ref: "@root/hashes.md/grammar/typescript.hash.md"
 - depends_on: "@root/hashes.md/errors.hash.md"

--- a/src/__tests__/usdc-listop-values.test.ts
+++ b/src/__tests__/usdc-listop-values.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   encodeTokenListOp,
+  encodePathListOp,
   decodeTokenListOp,
   SdfListOpSubListType,
   listOpValueRep,
@@ -116,6 +117,26 @@ describe('listOpValueRep', () => {
     expect(fields.isArray).toBe(false);
     expect(fields.isInlined).toBe(false);
     expect(fields.payload).toBe(1024n);
+  });
+});
+
+describe('encodePathListOp', () => {
+  it('produces a PathListOp-typed ValueRep', () => {
+    const enc = encodePathListOp({ explicit: [3] });
+    expect(enc.type).toBe(CrateDataType.PathListOp);
+    expect(enc.isArray).toBe(false);
+  });
+
+  it('shares the wire format with TokenListOp (only the type tag differs)', () => {
+    const tokenOp = encodeTokenListOp({ prepended: [1, 2, 3] });
+    const pathOp = encodePathListOp({ prepended: [1, 2, 3] });
+    expect(pathOp.bytes).toEqual(tokenOp.bytes);
+    expect(pathOp.type).not.toBe(tokenOp.type);
+  });
+
+  it('round-trips through decodeTokenListOp (the decoder is type-agnostic)', () => {
+    const enc = encodePathListOp({ explicit: [42] });
+    expect(decodeTokenListOp(enc.bytes).explicit).toEqual([42]);
   });
 });
 

--- a/src/__tests__/usdc-property-parser.test.ts
+++ b/src/__tests__/usdc-property-parser.test.ts
@@ -150,14 +150,33 @@ describe('parsePropertyKey — list-op metadata', () => {
   });
 });
 
+describe('parsePropertyKey — relationship keys', () => {
+  it('parses material:binding as a relationship', () => {
+    const r = parsePropertyKey('material:binding');
+    expect(r).toEqual({ kind: 'relationship', name: 'material:binding' });
+  });
+
+  it('parses material:binding:collection:foo as a relationship', () => {
+    const r = parsePropertyKey('material:binding:collection:foo');
+    expect(r).toEqual({
+      kind: 'relationship',
+      name: 'material:binding:collection:foo',
+    });
+  });
+
+  it('parses an explicit `rel myRel` declaration', () => {
+    const r = parsePropertyKey('rel myRel');
+    expect(r).toEqual({ kind: 'relationship', name: 'myRel' });
+  });
+
+  it('returns unsupported when `rel` is missing a name', () => {
+    expect(parsePropertyKey('rel ').kind).toBe('unsupported');
+  });
+});
+
 describe('parsePropertyKey — non-attribute keys (unsupported)', () => {
   it('returns unsupported for connection (.connect suffix)', () => {
     const r = parsePropertyKey('token outputs:surface.connect');
-    expect(r.kind).toBe('unsupported');
-  });
-
-  it('returns unsupported for material:binding', () => {
-    const r = parsePropertyKey('material:binding');
     expect(r.kind).toBe('unsupported');
   });
 

--- a/src/__tests__/usdc-usd-node-adapter.test.ts
+++ b/src/__tests__/usdc-usd-node-adapter.test.ts
@@ -113,11 +113,46 @@ describe('applyProperty — scalar dispatch', () => {
     expect(r.emitted).toBe(true);
   });
 
-  it('skips connection and relationship keys', () => {
+  it('skips connection keys (.connect suffix)', () => {
     const b = new UsdcLayerBuilder();
     const root = b.declarePrim('/Root', 'Material');
     expect(applyProperty(b, root, 'token outputs:surface.connect', '<x>').emitted).toBe(false);
-    expect(applyProperty(b, root, 'material:binding', '<x>').emitted).toBe(false);
+  });
+
+  it('emits a Relationship for material:binding (target as USDA-style <path>)', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Xform');
+    const mat = b.declarePrim('/Root/PlyMaterial', 'Material');
+    const r = applyProperty(b, root, 'material:binding', '</Root/PlyMaterial>');
+    expect(r.emitted).toBe(true);
+    void mat; // declared so the target resolves at serialize time
+  });
+
+  it('emits a Relationship for material:binding (target as bare path)', () => {
+    const b = new UsdcLayerBuilder();
+    b.declarePrim('/Root', 'Xform');
+    b.declarePrim('/Root/PlyMaterial', 'Material');
+    const root = b.declarePrim('/Root/Mesh', 'Mesh');
+    const r = applyProperty(b, root, 'material:binding', '/Root/PlyMaterial');
+    expect(r.emitted).toBe(true);
+  });
+
+  it('emits a Relationship for an array of target paths', () => {
+    const b = new UsdcLayerBuilder();
+    b.declarePrim('/Root', 'Xform');
+    b.declarePrim('/Root/A', 'Material');
+    b.declarePrim('/Root/B', 'Material');
+    const mesh = b.declarePrim('/Root/Mesh', 'Mesh');
+    const r = applyProperty(b, mesh, 'material:binding', ['</Root/A>', '</Root/B>']);
+    expect(r.emitted).toBe(true);
+  });
+
+  it('skips a relationship whose value is empty / non-absolute', () => {
+    const b = new UsdcLayerBuilder();
+    const root = b.declarePrim('/Root', 'Xform');
+    expect(applyProperty(b, root, 'material:binding', '').emitted).toBe(false);
+    expect(applyProperty(b, root, 'material:binding', 'NotAbsolute').emitted).toBe(false);
+    expect(applyProperty(b, root, 'material:binding', 42).emitted).toBe(false);
   });
 
   it('emits a TokenListOp for prepend apiSchemas', () => {

--- a/src/converters/shared/usdc/layer-builder.ts
+++ b/src/converters/shared/usdc/layer-builder.ts
@@ -53,15 +53,21 @@ import {
   encodeTokenArray,
   arrayValueRep,
 } from './array-values';
-import { encodeTokenListOp, type TokenListOpInput } from './listop-values';
+import {
+  encodePathListOp,
+  encodeTokenListOp,
+  type TokenListOpInput,
+} from './listop-values';
 import {
   CrateDataType,
   SdfSpecType,
   SdfSpecifier,
+  SdfVariability,
   inlineFloat,
   inlineInt,
   inlineToken,
   inlineSpecifier,
+  inlineVariability,
 } from './value-rep';
 
 /** Opaque handle returned by `declarePrim`; pass back to `add*Attribute`. */
@@ -93,6 +99,18 @@ interface SpecBuilder {
   fields: PendingField[];
 }
 
+/**
+ * Pending relationship — full resolution happens at `serialize()` time
+ * because target paths often reference prims that haven't been declared
+ * yet when `addRelationship` is called.
+ */
+interface PendingRelationship {
+  /** Index into `specBuilders` of this relationship's spec. */
+  specBuilderIndex: number;
+  /** Stringly-typed target paths to resolve at serialize time. */
+  targetPaths: string[];
+}
+
 export class UsdcLayerBuilder {
   private readonly tokens = new TokenTable();
   private readonly strings = new StringTable();
@@ -101,18 +119,26 @@ export class UsdcLayerBuilder {
   private readonly pendingArrays: PendingArray[] = [];
   /** Built-up prim/attribute spec list. Pseudo-root is index 0. */
   private readonly specBuilders: SpecBuilder[] = [];
+  /** Relationships awaiting target-path resolution at serialize time. */
+  private readonly pendingRelationships: PendingRelationship[] = [];
+  /** Maps a USD path string ("/Root/Materials/Foo") to its PathIndex. */
+  private readonly pathStringToIndex = new Map<string, number>();
   /** PATHS root, with children attached as prims/attributes are declared. */
   private readonly pseudoRoot: PathNode;
 
   /** Cached token indices for builtin field names. */
   private readonly tok_specifier: number;
   private readonly tok_typeName: number;
+  private readonly tok_targetPaths: number;
+  private readonly tok_variability: number;
 
   constructor() {
     // Pre-intern the builtin field tokens so they get small indices and are
     // available to every prim spec without re-checking.
     this.tok_specifier = this.tokens.intern('specifier');
     this.tok_typeName = this.tokens.intern('typeName');
+    this.tok_targetPaths = this.tokens.intern('targetPaths');
+    this.tok_variability = this.tokens.intern('variability');
 
     // Pseudo-root (path "/", spec type 7, no parent).
     this.pseudoRoot = {
@@ -126,6 +152,7 @@ export class UsdcLayerBuilder {
       specType: SdfSpecType.PseudoRoot,
       fields: [],
     });
+    this.pathStringToIndex.set('/', 0);
   }
 
   /**
@@ -174,6 +201,7 @@ export class UsdcLayerBuilder {
       children: [],
     };
     parent.children.push(node);
+    this.pathStringToIndex.set(path, newPathIndex);
     void parentSpec; // The builder doesn't need to update parent's fields here.
 
     const fields: PendingField[] = [
@@ -349,6 +377,59 @@ export class UsdcLayerBuilder {
   }
 
   /**
+   * Declare a relationship attached to `prim` whose targets are USD prim
+   * paths. Examples:
+   *
+   *   b.addRelationship(meshPrim, 'material:binding', ['/Root/Materials/Foo'])
+   *   b.addRelationship(prim, 'rel:proxyPrim', ['/Root/Proxy'])
+   *
+   * The relationship gets its own path entry under the prim (a property-
+   * typed child whose element name is `name`) and its own SPECS row with
+   * `SdfSpecType.Relationship`.
+   *
+   * Target paths are not resolved against the path table until
+   * `serialize()` runs — they may legally refer to prims declared later
+   * in the build sequence.
+   */
+  addRelationship(
+    prim: PrimHandle,
+    name: string,
+    targetPaths: ReadonlyArray<string>
+  ): void {
+    if (targetPaths.length === 0) {
+      throw new RangeError('addRelationship: targetPaths is empty');
+    }
+    const elementToken = this.tokens.intern(name);
+    const newPathIndex = this.specBuilders.length;
+    const node: PathNode = {
+      pathIndex: newPathIndex,
+      elementTokenIndex: elementToken,
+      isProperty: true,
+      children: [],
+    };
+    prim.node.children.push(node);
+
+    this.specBuilders.push({
+      pathIndex: newPathIndex,
+      specType: SdfSpecType.Relationship,
+      // The targetPaths field is filled in at serialize time once every
+      // referenced prim has had a chance to be declared. variability is
+      // uniform per the USD spec for relationships.
+      fields: [
+        {
+          tokenIndex: this.tok_variability,
+          rep: { kind: 'inline', value: inlineVariability(SdfVariability.Uniform) },
+        },
+      ],
+    });
+
+    this.pendingRelationships.push({
+      specBuilderIndex: newPathIndex,
+      targetPaths: [...targetPaths],
+    });
+  }
+
+  /**
    * Produce the complete USDC layer bytes. After this call, the builder's
    * internal state should be considered consumed; calling it twice will
    * produce identical output but is wasteful.
@@ -361,6 +442,32 @@ export class UsdcLayerBuilder {
     //
     // Strategy: lay sections out in the order the file will contain them and
     // resolve offsets as we go.
+
+    // Resolve every pending relationship's target paths to PathIndex values
+    // and emit the corresponding `targetPaths` field. This must happen
+    // BEFORE TOKENS is closed (resolution doesn't intern any tokens, but
+    // the encoded PathListOp does sit in pendingArrays which is consumed
+    // below).
+    for (const rel of this.pendingRelationships) {
+      const indices: number[] = new Array(rel.targetPaths.length);
+      for (let i = 0; i < rel.targetPaths.length; i++) {
+        const tp = rel.targetPaths[i];
+        const idx = this.pathStringToIndex.get(tp);
+        if (idx === undefined) {
+          throw new RangeError(
+            `serialize: relationship target path "${tp}" was never declared`
+          );
+        }
+        indices[i] = idx;
+      }
+      const enc = encodePathListOp({ explicit: indices });
+      const arrayId = this.pendingArrays.length;
+      this.pendingArrays.push({ encoded: enc });
+      this.specBuilders[rel.specBuilderIndex].fields.push({
+        tokenIndex: this.tok_targetPaths,
+        rep: { kind: 'array', arrayId },
+      });
+    }
 
     // Encode TOKENS first so the byte size is known. (TokenTable closed.)
     const tokensBytes = this.tokens.encode();

--- a/src/converters/shared/usdc/listop-values.ts
+++ b/src/converters/shared/usdc/listop-values.ts
@@ -43,8 +43,17 @@ export const SdfListOpSubListType = {
 export type SdfListOpSubListType =
   (typeof SdfListOpSubListType)[keyof typeof SdfListOpSubListType];
 
-/** Mutable description of a TokenListOp before serialization. */
-export interface TokenListOpInput {
+/**
+ * Mutable description of a SdfListOp before serialization.
+ *
+ * The wire format is identical for `TokenListOp`, `StringListOp`, `IntListOp`,
+ * `Int64ListOp`, `UIntListOp`, `UInt64ListOp`, and `PathListOp` — every
+ * element is a uint32 *index* that references some other table (the
+ * TOKENS table for tokens / strings, the PATHS table for paths). This
+ * type captures all of them; concrete encoders set the appropriate
+ * `CrateDataType` tag on the resulting ValueRep.
+ */
+export interface IndexListOpInput {
   isExplicit?: boolean;
   explicit?: ReadonlyArray<number>;
   added?: ReadonlyArray<number>;
@@ -53,6 +62,9 @@ export interface TokenListOpInput {
   prepended?: ReadonlyArray<number>;
   appended?: ReadonlyArray<number>;
 }
+
+/** Backwards-compatible alias kept so existing TokenListOp callers don't break. */
+export type TokenListOpInput = IndexListOpInput;
 
 function validateTokenIndices(label: string, items: ReadonlyArray<number>): void {
   for (let i = 0; i < items.length; i++) {
@@ -66,11 +78,14 @@ function validateTokenIndices(label: string, items: ReadonlyArray<number>): void
 }
 
 /**
- * Encode a TokenListOp as the bytes that go at a file offset, plus the
- * `EncodedArrayValue` envelope the layer-builder wants. The resulting
- * ValueRep has `type: TokenListOp`, `isArray: false`, `isCompressed: false`.
+ * Shared low-level encoder for any index-based ListOp. The caller supplies
+ * the `CrateDataType` tag that should appear on the resulting ValueRep
+ * (`TokenListOp` for tokens, `PathListOp` for paths, ...).
  */
-export function encodeTokenListOp(input: TokenListOpInput): EncodedArrayValue {
+function encodeIndexListOp(
+  input: IndexListOpInput,
+  type: CrateDataType
+): EncodedArrayValue {
   const sublists: { type: SdfListOpSubListType; items: ReadonlyArray<number> }[] = [];
   if (input.explicit && input.explicit.length > 0) {
     validateTokenIndices('explicit', input.explicit);
@@ -121,11 +136,29 @@ export function encodeTokenListOp(input: TokenListOpInput): EncodedArrayValue {
 
   return {
     bytes,
-    type: CrateDataType.TokenListOp,
+    type,
     isCompressed: false,
     count: sublists.length, // metadata only; not used by anyone today
     isArray: false,
   };
+}
+
+/**
+ * Encode a TokenListOp. Items are TokenIndex values into the TOKENS table.
+ * The resulting ValueRep has `type: TokenListOp`, `isArray: false`,
+ * `isCompressed: false`.
+ */
+export function encodeTokenListOp(input: IndexListOpInput): EncodedArrayValue {
+  return encodeIndexListOp(input, CrateDataType.TokenListOp);
+}
+
+/**
+ * Encode a PathListOp. Items are PathIndex values into the PATHS table.
+ * The resulting ValueRep has `type: PathListOp`, `isArray: false`,
+ * `isCompressed: false`.
+ */
+export function encodePathListOp(input: IndexListOpInput): EncodedArrayValue {
+  return encodeIndexListOp(input, CrateDataType.PathListOp);
 }
 
 /**

--- a/src/converters/shared/usdc/property-parser.ts
+++ b/src/converters/shared/usdc/property-parser.ts
@@ -46,6 +46,13 @@ export type ParsedProperty =
     opcode: ListOpOpcode;
   }
   | {
+    /** A relationship spec: either a built-in name like `material:binding`
+     * or an explicit `rel xxx` declaration. The value is the target path
+     * (or array of target paths). */
+    kind: 'relationship';
+    name: string;
+  }
+  | {
     kind: 'unsupported';
     /** The original key, kept verbatim so the caller can log / route it. */
     raw: string;
@@ -128,8 +135,17 @@ export function parsePropertyKey(rawKey: string): ParsedProperty {
   if (key.endsWith('.connect')) {
     return { kind: 'unsupported', raw: rawKey, reason: 'attribute connection' };
   }
-  if (key.startsWith('material:binding') || key.startsWith('rel ')) {
-    return { kind: 'unsupported', raw: rawKey, reason: 'relationship' };
+  // Built-in relationship name (USD's material-binding API).
+  if (key === 'material:binding' || key.startsWith('material:binding:')) {
+    return { kind: 'relationship', name: key };
+  }
+  // Explicit `rel <name>` form.
+  if (key.startsWith('rel ')) {
+    const name = key.slice(4).trim();
+    if (name.length === 0) {
+      return { kind: 'unsupported', raw: rawKey, reason: 'rel key missing name' };
+    }
+    return { kind: 'relationship', name };
   }
 
   // Tokenize on whitespace and pull qualifiers from the front.

--- a/src/converters/shared/usdc/usd-node-adapter.ts
+++ b/src/converters/shared/usdc/usd-node-adapter.ts
@@ -94,6 +94,9 @@ export function applyProperty(
   if (parsed.kind === 'list-op') {
     return applyListOp(builder, prim, parsed.name, parsed.opcode, value, key);
   }
+  if (parsed.kind === 'relationship') {
+    return applyRelationship(builder, prim, parsed.name, value, key);
+  }
   return applyTypedAttribute(builder, prim, parsed, value, key);
 }
 
@@ -287,6 +290,66 @@ const TOKEN_LIST_OP_NAMES = new Set([
  * shapes (PathListOp / ReferenceListOp / etc.) fall into the unsupported
  * bucket so the packager can fall back to USDA cleanly.
  */
+/**
+ * Dispatch a relationship key (`material:binding`, `rel xxx`, ...) to the
+ * layer-builder's `addRelationship`.
+ *
+ * The value can arrive in any of these shapes (depending on which converter
+ * built the source UsdNode):
+ *
+ *   "/Root/Materials/Foo"        — bare path, no decorators
+ *   "</Root/Materials/Foo>"       — USDA-style path literal with brackets
+ *   ["/Root/A", "/Root/B"]        — multiple targets
+ *
+ * The adapter strips the optional `<...>` brackets and routes empty values
+ * to the unsupported bucket (so the packager falls back rather than
+ * emitting an unbound relationship).
+ */
+function applyRelationship(
+  builder: UsdcLayerBuilder,
+  prim: PrimHandle,
+  name: string,
+  value: unknown,
+  rawKey: string
+): AdaptedProperty {
+  const targets = coerceTargetPaths(value);
+  if (!targets || targets.length === 0) {
+    return skipped(rawKey, `relationship "${name}": expected one or more target paths`);
+  }
+  for (const t of targets) {
+    if (!t.startsWith('/')) {
+      return skipped(rawKey, `relationship "${name}" target "${t}" is not absolute`);
+    }
+  }
+  builder.addRelationship(prim, name, targets);
+  return { rawKey, emitted: true };
+}
+
+function coerceTargetPaths(value: unknown): string[] | null {
+  if (typeof value === 'string') {
+    const stripped = stripPathLiteral(value);
+    return stripped.length > 0 ? [stripped] : null;
+  }
+  if (Array.isArray(value)) {
+    const out: string[] = [];
+    for (const v of value) {
+      if (typeof v !== 'string') return null;
+      const s = stripPathLiteral(v);
+      if (s.length === 0) return null;
+      out.push(s);
+    }
+    return out;
+  }
+  return null;
+}
+
+/** Strip optional `<...>` USDA brackets from a path literal. */
+function stripPathLiteral(s: string): string {
+  const t = s.trim();
+  if (t.startsWith('<') && t.endsWith('>')) return t.slice(1, -1).trim();
+  return t;
+}
+
 function applyListOp(
   builder: UsdcLayerBuilder,
   prim: PrimHandle,


### PR DESCRIPTION
## Summary

Adds Relationship spec support to the USDC encoder, unblocking
\`material:binding\` (the second of three remaining adapter blockers
called out in #126). Connection support is the only piece left before
PLY's \`layerFormat: 'usdc'\` flips from "falls back" to "actually emits
binary."

## What lands here (2 focused commits)

1. **PathListOp value encoder** — sibling of the existing TokenListOp
   encoder. Wire format is identical (both are SdfListOp<uint32-index>);
   only the CrateDataType tag differs. 3 new tests.
2. **Relationship wiring** end-to-end:
   - \`property-parser\` recognizes \`material:binding\`,
     \`material:binding:collection:foo\`, and \`rel xxx\` keys as
     \`{ kind: 'relationship', name }\`.
   - \`layer-builder\` gains \`addRelationship(prim, name, targetPaths)\`.
     Each call declares a property-typed child path, pushes a
     SpecBuilder with \`SdfSpecType.Relationship\` (variability=uniform),
     and queues the target paths for late resolution. \`serialize()\`
     walks pending relationships and emits a \`targetPaths\` field whose
     value is a PathListOp populated with the resolved PathIndex values.
   - \`usd-node-adapter\` dispatches \`relationship\` kinds. Accepts
     strings (with or without USDA \`<...>\` brackets) and string
     arrays. Non-absolute paths and bad shapes route to the unsupported
     bucket so the packager keeps falling back cleanly.

## What does NOT land here

- **Connection spec** (\`outputs:surface.connect\`) — \`SdfSpecType.Connection\`
  + connection-target value. Same shape as Relationship but the path
  table needs property paths (currently only prim paths are tracked).
- **\`usdcat\` byte-level validation** — the bytes round-trip through
  our own decoder; cross-validation against fixtures produced by
  Apple's reader is the gating step before flipping the
  \`layerFormat\` default to \`'usdc'\`.

## Test plan

- [x] All 332 tests pass (\`pnpm run test:run\`)
- [x] Type-check clean (\`pnpm run type-check\`)
- [x] 11 new tests across the three modules (3 PathListOp + 4 parser + 4 adapter)
- [ ] Follow-up: Connection spec
- [ ] Follow-up: PLY end-to-end emits \`model.usdc\` once Connection lands

Refs #122